### PR TITLE
redesign: hybrid condensed pin format

### DIFF
--- a/automated_test.py
+++ b/automated_test.py
@@ -22,6 +22,11 @@ def test_compress_decompress_random(dtype):
   recovered = crackle.decompress(binary)
   assert np.all(labels == recovered)
 
+  labels = np.random.randint(0,40,size=(100,100,10), dtype=dtype)
+  binary = crackle.compress(labels, allow_pins=True)
+  recovered = crackle.decompress(binary)
+  assert np.all(labels == recovered)
+
   labels = np.random.randint(0,40,size=(100,100,100), dtype=dtype)
   binary = crackle.compress(labels)
   recovered = crackle.decompress(binary)

--- a/src/crackle.hpp
+++ b/src/crackle.hpp
@@ -84,21 +84,22 @@ std::vector<unsigned char> compress_helper(
 	
 	std::vector<unsigned char> labels_binary;
 	if (label_format == LabelFormat::PINS_VARIABLE_WIDTH) {
-		auto [all_pins, num_components_per_slice] = crackle::pins::compute(labels, sx, sy, sz);
+		auto [all_pins, num_components_per_slice, num_components] = crackle::pins::compute(labels, sx, sy, sz);
 		labels_binary = crackle::labels::encode_condensed_pins<LABEL, STORED_LABEL>(
 			all_pins,
 			sx, sy, sz,
-			header.pin_index_width()
+			header.pin_index_width(),
+			num_components
 		);
 	}
-	else if (label_format == LabelFormat::PINS_FIXED_WIDTH) {
-		auto [all_pins, num_components_per_slice] = crackle::pins::compute(labels, sx, sy, sz);
-		labels_binary = crackle::labels::encode_fixed_width_pins<LABEL, STORED_LABEL>(
-			all_pins,
-			sx, sy, sz,
-			header.pin_index_width(), header.depth_width()
-		);		
-	}
+	// else if (label_format == LabelFormat::PINS_FIXED_WIDTH) {
+	// 	auto [all_pins, num_components_per_slice, num_components] = crackle::pins::compute(labels, sx, sy, sz);
+	// 	labels_binary = crackle::labels::encode_fixed_width_pins<LABEL, STORED_LABEL>(
+	// 		all_pins,
+	// 		sx, sy, sz,
+	// 		header.pin_index_width(), header.depth_width()
+	// 	);		
+	// }
 	else {
 		labels_binary = crackle::labels::encode_flat<LABEL, STORED_LABEL>(labels, sx, sy, sz);
 	}

--- a/src/crackle.hpp
+++ b/src/crackle.hpp
@@ -89,7 +89,7 @@ std::vector<unsigned char> compress_helper(
 			all_pins,
 			sx, sy, sz,
 			header.pin_index_width(),
-			num_components
+			num_components_per_slice, num_components
 		);
 	}
 	// else if (label_format == LabelFormat::PINS_FIXED_WIDTH) {

--- a/src/labels.hpp
+++ b/src/labels.hpp
@@ -314,6 +314,7 @@ std::vector<unsigned char> encode_condensed_pins(
 		for (uint64_t j : pin_repr) {
 			i += crackle::lib::itocd(pins[j].depth(), binary, i, depth_width);
 		}
+
 		std::vector<uint32_t> cc_ids;
 		cc_ids.reserve(cc_repr.size() * cc_efficient_threshold);
 		for (uint64_t j : cc_repr) {
@@ -334,7 +335,6 @@ std::vector<unsigned char> encode_condensed_pins(
 			i += crackle::lib::itocd(ccid, binary, i, cc_label_width);
 		}
 	}
-
 
 	binary.resize(i);
 	return binary;
@@ -566,8 +566,10 @@ std::vector<LABEL> decode_condensed_pins(
 	std::vector<LABEL> label_map(N, bgcolor);
 
 	std::vector<PinType> pins;
+	
 	for (uint64_t i = offset, label = 0; label < uniq.size(); label++) {
 		uint64_t num_pins = crackle::lib::ctoid(buf, i, num_pins_width);
+
 		i += num_pins_width;
 		for (uint64_t j = 0; j < num_pins; j++) {
 			uint64_t index = crackle::lib::ctoid(buf, i + (j * index_width), index_width);

--- a/src/labels.hpp
+++ b/src/labels.hpp
@@ -101,7 +101,7 @@ std::vector<unsigned char> encode_flat(
 
 template <typename STORED_LABEL>
 STORED_LABEL find_bgcolor(
-	std::unordered_map<uint64_t, std::vector<crackle::pins::Pin<uint64_t, uint64_t, uint64_t>>>& all_pins,
+	std::unordered_map<uint64_t, std::vector<crackle::pins::CandidatePin>>& all_pins,
 	const int64_t sz
 ) {
 	// find bg color, pick the most pins
@@ -116,13 +116,13 @@ STORED_LABEL find_bgcolor(
 			max_pins = pins.size();
 			max_pins_depth = 0;
 			for (auto& pin : pins) {
-				max_pins_depth += pin.depth;
+				max_pins_depth += pin.depth();
 			}
 		} 
 		else if (pins.size() == max_pins) {
 			uint64_t candidate_max_depth = 0;
 			for (auto& pin : pins) {
-				candidate_max_depth += pin.depth;
+				candidate_max_depth += pin.depth();
 			}
 			if (candidate_max_depth > max_pins_depth) {
 				bgcolor = static_cast<STORED_LABEL>(label);
@@ -203,9 +203,9 @@ std::vector<unsigned char> encode_fixed_width_pins(
 
 template <typename LABEL, typename STORED_LABEL>
 std::vector<unsigned char> encode_condensed_pins(
-	std::unordered_map<uint64_t, std::vector<crackle::pins::Pin<uint64_t, uint64_t, uint64_t>>>& all_pins,
+	std::unordered_map<uint64_t, std::vector<crackle::pins::CandidatePin>>& all_pins,
 	const int64_t sx, const int64_t sy, const int64_t sz,
-	const int64_t index_width
+	const int64_t index_width, const uint64_t num_components
 ) {
 	STORED_LABEL bgcolor = find_bgcolor<STORED_LABEL>(all_pins, sz);
 	all_pins.erase(bgcolor);
@@ -217,7 +217,7 @@ std::vector<unsigned char> encode_condensed_pins(
 		max_pins = std::max(static_cast<uint64_t>(pins.size()), max_pins);
 		total_pins += pins.size();
 		for (auto& pin : pins) {
-			max_depth = std::max(max_depth, pin.depth);
+			max_depth = std::max(max_depth, pin.depth());
 		}
 	}
 
@@ -230,24 +230,43 @@ std::vector<unsigned char> encode_condensed_pins(
 
 	uint8_t num_pins_width = crackle::lib::compute_byte_width(max_pins);
 	uint8_t depth_width = crackle::lib::compute_byte_width(max_depth);
+	uint8_t cc_label_width = crackle::lib::compute_byte_width(num_components);
 
-	uint8_t combined_width = static_cast<uint8_t>(log2(num_pins_width)) | (static_cast<uint8_t>(log2(depth_width)) << 2);
+	const uint8_t pin_bytes = index_width + depth_width;
+	const uint8_t cc_efficient_threshold = pin_bytes / cc_label_width;
 
-	struct {
+	uint8_t combined_width = (
+		static_cast<uint8_t>(log2(num_pins_width))
+		| (static_cast<uint8_t>(log2(depth_width)) << 2)
+		| (static_cast<uint8_t>(log2(cc_label_width)) << 4)
+	);
+
+	struct CmpIndex {
+		uint64_t sx;
+		uint64_t sy;
+
+		CmpIndex(uint64_t _sx, uint64_t _sy) 
+			: sx(_sx), sy(_sy)
+		{}
+
 		bool operator()(
-			crackle::pins::Pin<uint64_t, uint64_t, uint64_t>& a, 
-			crackle::pins::Pin<uint64_t, uint64_t, uint64_t>& b
+			crackle::pins::CandidatePin& a, 
+			crackle::pins::CandidatePin& b
 		) const { 
-			return a.index < b.index; 
+			return a.start_idx(sx, sy) < b.start_idx(sx, sy); 
 		}
-	} CmpIndex;
+	};
 
+	const CmpIndex cmp(sx,sy);
+
+	// overestimate size using more expensive pins
+	// and then resize at end
 	std::vector<unsigned char> binary(
 		sizeof(STORED_LABEL) // bgcolor
 		+ 8 // num labels
 		+ sizeof(STORED_LABEL) * all_labels.size() // unique
 		+ 1 // depth size, num_pins_size
-		+ (num_pins_width * all_labels.size())
+		+ (2 * num_pins_width * all_labels.size())
 		+ (index_width + depth_width) * total_pins
 	);
 
@@ -261,22 +280,61 @@ std::vector<unsigned char> encode_condensed_pins(
 
 	for (uint64_t label = 0; label < all_labels.size(); label++) {
 		auto& pins = all_pins[all_labels[label]];
-		std::sort(pins.begin(), pins.end(), CmpIndex);
-		if (pins.size() > 1) {
-			for (uint64_t j = pins.size() - 1; j >= 1; j--) {
-				pins[j].index -= pins[j-1].index;
+		std::sort(pins.begin(), pins.end(), cmp);
+
+		std::vector<uint64_t> pin_repr;
+		std::vector<uint64_t> cc_repr;
+		
+		for (uint64_t j = 0; j < pins.size(); j++) {
+			auto& pin = pins[j];
+			if (pin.depth() < cc_efficient_threshold) {
+				cc_repr.push_back(j);
+			}
+			else {
+				pin_repr.push_back(j);
 			}
 		}
 
-		i += crackle::lib::itocd(pins.size(), binary, i, num_pins_width);
-		for (auto& pin : pins) {
-			i += crackle::lib::itocd(pin.index, binary, i, index_width);
+		std::vector<uint64_t> pin_index;
+		pin_index.reserve(pins.size());
+		for (uint64_t j : pin_repr) {
+			pin_index.push_back(pins[j].start_idx(sx, sy));
 		}
-		for (auto& pin : pins) {
-			i += crackle::lib::itocd(pin.depth, binary, i, depth_width);
+
+		if (pin_index.size() > 1) {
+			for (uint64_t j = pin_index.size() - 1; j >= 1; j--) {
+				pin_index[j] -= pin_index[j-1];
+			}
+		}
+
+		i += crackle::lib::itocd(pin_repr.size(), binary, i, num_pins_width);
+		for (uint64_t index : pin_index) {
+			i += crackle::lib::itocd(index, binary, i, index_width);
+		}
+		for (uint64_t j : pin_repr) {
+			i += crackle::lib::itocd(pins[j].depth(), binary, i, depth_width);
+		}
+		i += crackle::lib::itocd(cc_repr.size(), binary, i, num_pins_width);
+		std::vector<uint32_t> cc_ids;
+		cc_ids.reserve(cc_repr.size() * cc_efficient_threshold);
+		for (uint64_t j : cc_repr) {
+			auto& pin = pins[j];
+			for (uint32_t ccid : pin.ccids) {
+				cc_ids.push_back(ccid);
+			}
+		}
+		std::sort(cc_ids.begin(), cc_ids.end());
+		if (cc_ids.size() > 1) {
+			for (uint64_t j = cc_ids.size() - 1; j >= 1; j--) {
+				cc_ids[j] -= cc_ids[j-1];
+			}
+		}
+		for (uint32_t ccid : cc_ids) {
+			i += crackle::lib::itocd(ccid, binary, i, cc_label_width);
 		}
 	}
 
+	binary.resize(i);
 	return binary;
 }
 
@@ -501,6 +559,9 @@ std::vector<LABEL> decode_condensed_pins(
 
 	const uint8_t num_pins_width = pow(2, (combined_width & 0b11));
 	const uint8_t depth_width = pow(2, (combined_width >> 2) & 0b11);
+	const uint8_t cc_label_width = pow(2, (combined_width >> 4) & 0b11);
+
+	std::vector<LABEL> label_map(N, bgcolor);
 
 	std::vector<PinType> pins;
 	for (uint64_t i = offset, label = 0; label < uniq.size(); label++) {
@@ -517,14 +578,24 @@ std::vector<LABEL> decode_condensed_pins(
 			}
 		}
 		i += num_pins * (index_width + depth_width);
+
+		uint64_t num_cc_labels = crackle::lib::ctoid(buf, i, num_pins_width);
+		i += num_pins_width;
+		std::vector<uint32_t> cc_labels(num_cc_labels);
+		for (uint64_t j = 0; j < num_cc_labels; j++) {
+			cc_labels[j] = crackle::lib::ctoid(buf, i, cc_label_width);
+			i += cc_label_width;
+		}
+		for (uint64_t j = 1; j < num_cc_labels; j++) {
+			cc_labels[j] += cc_labels[j-1];
+			label_map[cc_labels[j]] = label;
+		}
 	}
 
 	const int64_t sx = header.sx;
 	const int64_t sy = header.sy;
-
 	const int64_t sxy = sx * sy;
 
-	std::vector<LABEL> label_map(N, bgcolor);
 	for (auto& pin : pins) {
 		int64_t pin_z = pin.index / sxy;
 		int64_t loc = pin.index - (pin_z * sxy);

--- a/src/labels.hpp
+++ b/src/labels.hpp
@@ -592,7 +592,9 @@ std::vector<LABEL> decode_condensed_pins(
 		}
 		for (uint64_t j = 1; j < num_cc_labels; j++) {
 			cc_labels[j] += cc_labels[j-1];
-			label_map[cc_labels[j]] = label;
+		}
+		for (uint64_t j = 0; j < num_cc_labels; j++) {
+			label_map[cc_labels[j]] = uniq[label];
 		}
 	}
 

--- a/src/labels.hpp
+++ b/src/labels.hpp
@@ -618,7 +618,7 @@ std::vector<LABEL> decode_condensed_pins(
 			cc_labels[j] += cc_labels[j-1];
 		}
 		for (uint64_t j = 0; j < num_cc_labels; j++) {
-			if (cc_labels[j] >= component_right_offset) {
+			if (cc_labels[j] < component_left_offset || cc_labels[j] >= component_right_offset) {
 				continue;
 			}
 			label_map[cc_labels[j] - component_left_offset] = uniq[label];

--- a/src/labels.hpp
+++ b/src/labels.hpp
@@ -571,7 +571,13 @@ std::vector<LABEL> decode_condensed_pins(
 		header, labels_binary.data(), offset, header.num_grids(), component_width,
 		z_start, z_end
 	);
-	component_right_offset = N - component_right_offset;
+
+	uint64_t N_all = 0;
+	for (uint64_t j = 0; j < components.size(); j++) {
+		N_all += components[j];
+	}
+
+	component_right_offset = N_all - component_right_offset;
 	offset += component_width * header.num_grids();
 
 	uint8_t combined_width = crackle::lib::ctoi<uint8_t>(buf, offset);

--- a/src/labels.hpp
+++ b/src/labels.hpp
@@ -314,7 +314,6 @@ std::vector<unsigned char> encode_condensed_pins(
 		for (uint64_t j : pin_repr) {
 			i += crackle::lib::itocd(pins[j].depth(), binary, i, depth_width);
 		}
-		i += crackle::lib::itocd(cc_repr.size(), binary, i, num_pins_width);
 		std::vector<uint32_t> cc_ids;
 		cc_ids.reserve(cc_repr.size() * cc_efficient_threshold);
 		for (uint64_t j : cc_repr) {
@@ -329,10 +328,13 @@ std::vector<unsigned char> encode_condensed_pins(
 				cc_ids[j] -= cc_ids[j-1];
 			}
 		}
+
+		i += crackle::lib::itocd(cc_ids.size(), binary, i, num_pins_width);
 		for (uint32_t ccid : cc_ids) {
 			i += crackle::lib::itocd(ccid, binary, i, cc_label_width);
 		}
 	}
+
 
 	binary.resize(i);
 	return binary;


### PR DESCRIPTION
For very small pins (e.g. depth 0 or 1) the pin encoding might be 5 or 6 bytes while the encoding of a single CC label might be one or two bytes. For small pins, we scrap the pin and just use the CC code.

This update also includes an improvement that shrinks pins closer to what their actual contribution is, which makes them more compressible and can improve decode time (less time scanning the cc_labels).