### PR TITLE
BREAKING: feat: finite context modeling of crack codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ See benchmarks for more information on Crackle's size and compute effiency.
 | num_label_bytes   | Any.              | u32      | Number of bytes of the labels section. Note the labels come in at least two format types.          |
 
 
-Format Field (u16): DDSSCLLFGRRRRRRR (each letter represents a bit, left is LSB)
+Format Field (u16): DDSSCLLFGOOOORRR (each letter represents a bit, left is LSB)
 
 DD: 2^(DD) = byte width of returned array (1,2,4,8 bytes)  
 SS: 2^(SS) = byte width of stored labels (sometimes you can store values in 2 bytes when the final array is 8 bytes)  
@@ -88,6 +88,7 @@ C: 1: crack codes denote impermissible boundaries 0: they denote permissible bou
 LL: 0: "flat" label format, 1: fixed width pins (unused?) 2: variable width pins 3: reserved  
 F: whether the array is to be rendered as C (0) or F (1) order
 G: Signed (if (1), data are signed int, otherwise unsigned int)
+OOOO: Nth-Order of Markov Chain (as an unsigned integer, typical values 0, or 3 to 7). If 0, markov compression is disabled.
 R: Reserved
 
 ### Flat Label Format
@@ -138,10 +139,11 @@ A fixed width variant of pins has also been developed but is not enabled. It fre
 
 ### Crack Code Format
 
-
-CRACK CODE: `| CHAIN 0 | CHAIN 1 | ... | CHAIN N |`
+CRACK CODE: `MARKOV MODEL | CHAIN 0 | CHAIN 1 | ... | CHAIN N |`
 
 CHAIN: `| BEGINNING OF CHAIN INDEX (sizeof(sx * sy)) | BIT PACKED MOVES (2 bits each) |`
+
+MARKOV MODEL (if enabled): `priority order of moves UDLR packed per a byte`. 4^order bytes.
 
 The BEGINNING OF CHAIN INDEX (BOC) locates the grid vertex where the crack code will begin. Vertices are the corners of the pixel grid, with 0 at the top left and sx\*sy-1 at the bottom right (fortran order). 
 

--- a/automated_test.py
+++ b/automated_test.py
@@ -11,24 +11,27 @@ DTYPE = [
 ]
 
 @pytest.mark.parametrize('dtype', DTYPE)
-def test_compress_decompress_random(dtype):
+@pytest.mark.parametrize('markov_model_order', [1,2,3])
+def test_compress_decompress_random(dtype, markov_model_order):
   labels = np.random.randint(0,5,size=(4,4,1), dtype=dtype)
-  binary = crackle.compress(labels)
+  binary = crackle.compress(labels, markov_model_order=markov_model_order)
   recovered = crackle.decompress(binary)
+  print(labels.T)
+  print(recovered.T)
   assert np.all(labels == recovered)
 
   labels = np.random.randint(0,40,size=(1000,999,1), dtype=dtype)
-  binary = crackle.compress(labels)
+  binary = crackle.compress(labels, markov_model_order=markov_model_order)
   recovered = crackle.decompress(binary)
   assert np.all(labels == recovered)
 
   labels = np.random.randint(0,40,size=(100,100,10), dtype=dtype)
-  binary = crackle.compress(labels, allow_pins=True)
+  binary = crackle.compress(labels, allow_pins=True, markov_model_order=markov_model_order)
   recovered = crackle.decompress(binary)
   assert np.all(labels == recovered)
 
   labels = np.random.randint(0,40,size=(100,100,100), dtype=dtype)
-  binary = crackle.compress(labels)
+  binary = crackle.compress(labels, markov_model_order=markov_model_order)
   recovered = crackle.decompress(binary)
   assert np.all(labels == recovered)
 

--- a/automated_test.py
+++ b/automated_test.py
@@ -11,7 +11,7 @@ DTYPE = [
 ]
 
 @pytest.mark.parametrize('dtype', DTYPE)
-@pytest.mark.parametrize('markov_model_order', [1,2,3])
+@pytest.mark.parametrize('markov_model_order', [0,1,2,3])
 def test_compress_decompress_random(dtype, markov_model_order):
   labels = np.random.randint(0,5,size=(4,4,1), dtype=dtype)
   binary = crackle.compress(labels, markov_model_order=markov_model_order)

--- a/crackle/codec.py
+++ b/crackle/codec.py
@@ -310,7 +310,11 @@ def decompress_range(binary:bytes, z_start:Optional[int], z_end:Optional[int]) -
 
   return labels
 
-def compress(labels:np.ndarray, allow_pins:bool = False) -> bytes:
+def compress(
+  labels:np.ndarray, 
+  allow_pins:bool = False,
+  markov_model_order:int = 0
+) -> bytes:
   """
   Compress the 3D labels array into a Crackle bytestream.
 
@@ -329,5 +333,5 @@ def compress(labels:np.ndarray, allow_pins:bool = False) -> bytes:
 
   f_order = labels.flags.f_contiguous
   labels = np.asfortranarray(labels)
-  return fastcrackle.compress(labels, allow_pins, f_order, 0)
+  return fastcrackle.compress(labels, allow_pins, f_order, markov_model_order)
 

--- a/crackle/codec.py
+++ b/crackle/codec.py
@@ -329,5 +329,5 @@ def compress(labels:np.ndarray, allow_pins:bool = False) -> bytes:
 
   f_order = labels.flags.f_contiguous
   labels = np.asfortranarray(labels)
-  return fastcrackle.compress(labels, allow_pins, f_order)
+  return fastcrackle.compress(labels, allow_pins, f_order, 0)
 

--- a/crackle_cli/cli.py
+++ b/crackle_cli/cli.py
@@ -71,7 +71,7 @@ def decompress_file(src):
 		print(f"crackle: {src} could not be decoded.")
 		return
 
-	dest = src.replace(".ckl", "").replace(".gz", "")
+	dest = src.replace(".ckl", "").replace(".gz", "").replace(".xz", "").replace(".lzma", "")
 	_, ext = os.path.splitext(dest)
 	
 	if ext != ".npy":

--- a/crackle_cli/cli.py
+++ b/crackle_cli/cli.py
@@ -25,8 +25,9 @@ class Tuple3(click.ParamType):
 @click.option("-c/-d", "--compress/--decompress", default=True, is_flag=True, help="Compress from or decompress to a numpy .npy file.", show_default=True)
 @click.option('-i', "--info", default=False, is_flag=True, help="Print the header for the file.", show_default=True)
 @click.option('--allow-pins', default=False, is_flag=True, help="Allow pin encoding.", show_default=True)
+@click.option('-m', '--markov', default=0, help="If >0, use this order of markov compression for the crack code.", show_default=True)
 @click.argument("source", nargs=-1)
-def main(compress, info, allow_pins, source):
+def main(compress, info, allow_pins, markov, source):
 	"""
 	Compress and decompress crackle (.ckl) files to and from numpy (.npy) files.
 
@@ -42,7 +43,7 @@ def main(compress, info, allow_pins, source):
 			continue
 
 		if compress:
-			compress_file(src, allow_pins)
+			compress_file(src, allow_pins, markov)
 		else:
 			decompress_file(src)
 
@@ -88,7 +89,7 @@ def decompress_file(src):
 		print(f"crackle: Unable to write {dest}. Aborting.")
 		sys.exit()
 
-def compress_file(src, allow_pins):
+def compress_file(src, allow_pins, markov):
 	try:
 		data = np.load(src)
 	except ValueError:
@@ -99,7 +100,7 @@ def compress_file(src, allow_pins):
 		return
 
 	dest = f"{src}.ckl"
-	crackle.save(data, dest, allow_pins=allow_pins)
+	crackle.save(data, dest, allow_pins=allow_pins, markov_model_order=int(markov))
 	del data
 
 	try:

--- a/src/crackcodes.hpp
+++ b/src/crackcodes.hpp
@@ -177,11 +177,11 @@ struct Graph {
 	}
 };
 
-std::vector<std::vector<uint64_t>>
-symbols_to_integers(
+robin_hood::unordered_node_map<uint64_t, std::vector<uint8_t>>
+symbols_to_codepoints(
 	std::vector<std::pair<int64_t, std::vector<char>>> &chains
 ) {
-	std::vector<std::vector<uint64_t>> encoded_chains;
+	robin_hood::unordered_node_map<uint64_t, std::vector<uint8_t>> encoded_chains;
 
 	const uint64_t BRANCH[2] = { DirectionCode::UP, DirectionCode::DOWN };
 	const uint64_t BRANCH2[2] = { DirectionCode::LEFT, DirectionCode::RIGHT };
@@ -189,9 +189,9 @@ symbols_to_integers(
 	const uint64_t TERM2[2] = { DirectionCode::RIGHT, DirectionCode::LEFT };
 
 	for (auto [node, chain] : chains) {
-		std::vector<uint64_t> code;
+		std::vector<uint8_t> code;
 		code.reserve(chain.size());
-		code.push_back(node);
+
 		for (uint64_t i = 0; i < chain.size(); i++) {
 			char symbol = chain[i];
 			if (symbol == 's') {
@@ -233,7 +233,7 @@ symbols_to_integers(
 				throw std::runtime_error("Invalid symbol.");
 			}
 		}
-		encoded_chains.push_back(code);
+		encoded_chains[node] = std::move(code);
 	}
 
 	return encoded_chains;
@@ -298,6 +298,97 @@ void remove_initial_branch(
 	node = pos_x + sxe * pos_y;
 }
 
+std::vector<uint64_t> read_boc_index(
+	const std::vector<unsigned char>& binary,
+	const uint64_t sx, const uint64_t sy
+) {
+	std::vector<uint64_t> nodes;
+
+	const uint64_t sxe = sx + 1;
+
+	const uint64_t x_width = crackle::lib::compute_byte_width(sx+1);
+	const uint64_t y_width = crackle::lib::compute_byte_width(sy+1);
+
+	uint64_t idx = 4; // skip over index size
+	uint64_t num_y = crackle::lib::ctoid(binary, idx, y_width);
+	idx += y_width;
+
+	uint64_t y = 0; 
+
+	for (uint64_t yi = 0; yi < num_y; yi++) {
+		y += crackle::lib::ctoid(binary, idx, y_width);
+		idx += y_width;
+
+		uint64_t num_x = crackle::lib::ctoid(binary, idx, x_width);
+		idx += x_width;
+
+		uint64_t x = 0;
+		for (uint64_t xi = 0; xi < num_x; xi++) {
+			x += crackle::lib::ctoid(binary, idx, x_width);
+			idx += x_width;
+			nodes.push_back(x + sxe * y);
+		}
+	}
+
+	return nodes;
+}
+
+std::vector<unsigned char> write_boc_index(
+	const std::vector<uint64_t>& sorted_nodes,
+	const uint64_t sx, const uint64_t sy
+) {
+	const uint64_t sxe = sx + 1;
+	const uint64_t sye = sy + 1;
+
+	const uint64_t x_width = crackle::lib::compute_byte_width(sx+1);
+	const uint64_t y_width = crackle::lib::compute_byte_width(sy+1);
+
+	// beginning of chain index
+	robin_hood::unordered_node_map<uint64_t, std::vector<uint64_t>> boc(sye);
+
+	for (uint64_t node : sorted_nodes) {
+		uint64_t y = node / sxe;
+		uint64_t x = node - sxe * y;
+		boc[y].push_back(x);
+	}
+
+	std::vector<uint64_t> all_y;
+	for (auto pair : boc) {
+		all_y.push_back(pair.first);
+	}
+	std::sort(all_y.begin(), all_y.end());
+
+	uint64_t index_size = y_width;
+	for (uint64_t y : all_y) {
+		index_size += y_width;
+		index_size += (boc[y].size() + 1) * x_width;
+	}
+
+	std::vector<unsigned char> binary(4 + index_size);
+
+	uint64_t idx = 0;
+	idx += crackle::lib::itocd(index_size, binary, idx, 4);
+	idx += crackle::lib::itocd(all_y.size(), binary, idx, y_width);
+	
+	for (uint64_t i = 0; i < all_y.size(); i++) {
+		if (i == 0) {
+			idx += crackle::lib::itocd(all_y[0], binary, idx, y_width);
+		}
+		else {
+			idx += crackle::lib::itocd(all_y[i] - all_y[i-1], binary, idx, y_width);
+		}
+		uint64_t y = all_y[i];
+		idx += crackle::lib::itocd(boc[y].size(), binary, idx, x_width);
+		uint64_t last_x = 0;
+		for (uint64_t x : boc[y]) {
+			idx += crackle::lib::itocd(x - last_x, binary, idx, x_width);
+			last_x = x;
+		}
+	}
+
+	return binary;
+}
+
 struct pair_hash {
 	size_t operator()(const std::pair<int64_t, int64_t>& p) const {
 		return p.first + 31 * p.second;
@@ -306,7 +397,7 @@ struct pair_hash {
 
 
 template <typename LABEL>
-std::vector<std::vector<uint64_t>>
+robin_hood::unordered_node_map<uint64_t, std::vector<uint8_t>>
 create_crack_codes(
 	const LABEL* labels,
 	const int64_t sx, const int64_t sy,
@@ -323,7 +414,7 @@ create_crack_codes(
   std::vector<uint8_t> revisit_ct((sx+1)*(sy+1));
 
   if (n_clusters == 0) {
-    return symbols_to_integers(chains);
+    return symbols_to_codepoints(chains);
   }
 
   std::vector<int64_t> neighbors;
@@ -423,27 +514,37 @@ create_crack_codes(
     );
   }
 
-  return symbols_to_integers(chains);
+  auto codepoint_chains = symbols_to_codepoints(chains);
+  for (auto& [node, codepoints] : codepoint_chains) {
+  		for (uint64_t i = codepoints.size() - 1; i >= 1; i--) {
+  			codepoints[i] -= codepoints[i-1];
+  			if (codepoints[i] > 3) {
+  				codepoints[i] += 4;
+  			}
+  		}
+  }
+  return codepoint_chains;
 }
 
 std::vector<unsigned char> pack_codes(
-	const std::vector<std::vector<uint64_t>>& chains,
+	const robin_hood::unordered_node_map<uint64_t, std::vector<uint8_t>>& chains,
 	const uint64_t sx, const uint64_t sy
 ) {
-	uint64_t byte_width = crackle::lib::compute_byte_width((sx+1) * (sy+1));
+	
+	std::vector<uint64_t> nodes;
+	for (auto& [node, code] : chains) {
+		nodes.push_back(node);
+	}
+	std::sort(nodes.begin(), nodes.end());
 
-	std::vector<unsigned char> binary;
+	std::vector<unsigned char> binary = write_boc_index(nodes, sx, sy);
 
-	for (auto& chain : chains) {
-		// serialize node
-		for (uint64_t i = 0; i < byte_width; i++) {
-			binary.push_back((chain[0] >> (8*i)) & 0xff);
-		}
-
-		uint64_t all_moves = chain.size() - 1;
+	for (uint64_t node : nodes) {
+		auto& chain = chains[node];
+		uint64_t all_moves = chain.size();
 		all_moves -= (all_moves % 4);
 
-		uint64_t i = 1;
+		uint64_t i = 0;
 		uint8_t encoded = 0;
 		while (i < all_moves) {
 			encoded = 0;
@@ -487,18 +588,13 @@ encode_boundaries(
 	return binary_components;
 }
 
-std::unordered_map<uint64_t, std::vector<unsigned char>> 
-unpack_binary(
-	const std::vector<unsigned char> &code, 
-	const uint64_t sx, const uint64_t sy
+robin_hood::unordered_node_map<uint64_t, std::vector<unsigned char>> 
+codepoints_to_symbols(
+	const std::vector<uint64_t>& sorted_nodes,
+	const std::vector<uint8_t>& codepoints
 ) {
-	std::unordered_map<uint64_t, std::vector<unsigned char>> chains;
 
-	if (code.size() == 0) {
-		return chains;
-	}
-
-	uint64_t index_width = crackle::lib::compute_byte_width((sx+1) * (sy+1));
+	robin_hood::unordered_node_map<uint64_t, std::vector<unsigned char>> chains;
 
 	std::vector<unsigned char> symbols;
 	symbols.reserve(code.size() * 4 * 2);
@@ -508,42 +604,44 @@ unpack_binary(
 
 	char remap[4] = { 'u', 'r', 'l', 'd' };
 
-	for (uint64_t i = 0; i < code.size(); i++) {
+	uint64_t node_i = 0;
+
+	for (uint64_t i = 0; i < codepoints.size(); i++) {
 		if (branches_taken == 0) {
-			node = crackle::lib::ctoid(code.data(), i, index_width);
-			i += index_width - 1; // -1 b/c it will be incremented by for loop
+			if (node_i >= nodes.size()) {
+				throw std::runtime_error("corrupted crack code.");
+			}
+			node = nodes[node_i];
+			node_i++;
+			i--; // b/c i will be incremented
 			branches_taken = 1;
 			continue;
 		}
 
-		for (uint64_t j = 0; j < 4; j++) {
-			uint8_t move = static_cast<uint8_t>((code[i] >> (2*j)) & 0b11);
-
-			if (symbols.size()) {
-				if (
-					(move == DirectionCode::UP && symbols.back() == 'd')
-					|| (move == DirectionCode::LEFT && symbols.back() == 'r')
-				) {
-					symbols.back() = 't';
-					branches_taken--;
-					if (branches_taken == 0) {
-						break;
-					}
+		if (symbols.size()) {
+			if (
+				(move == DirectionCode::UP && symbols.back() == 'd')
+				|| (move == DirectionCode::LEFT && symbols.back() == 'r')
+			) {
+				symbols.back() = 't';
+				branches_taken--;
+				if (branches_taken == 0) {
+					break;
 				}
-				else if (
-					(move == DirectionCode::DOWN && symbols.back() == 'u')
-					|| (move == DirectionCode::RIGHT && symbols.back() == 'l')
-				) {
-					symbols.back() = 'b';
-					branches_taken++;
-				}
-				else {
-					symbols.push_back(remap[move]);
-				}
+			}
+			else if (
+				(move == DirectionCode::DOWN && symbols.back() == 'u')
+				|| (move == DirectionCode::RIGHT && symbols.back() == 'l')
+			) {
+				symbols.back() = 'b';
+				branches_taken++;
 			}
 			else {
 				symbols.push_back(remap[move]);
 			}
+		}
+		else {
+			symbols.push_back(remap[move]);
 		}
 
 		if (branches_taken == 0) {
@@ -555,6 +653,33 @@ unpack_binary(
 	}
 
 	return chains;
+}
+
+robin_hood::unordered_node_map<uint64_t, std::vector<unsigned char>> 
+unpack_binary(
+	const std::vector<unsigned char> &code, 
+	const uint64_t sx, const uint64_t sy
+) {
+	if (code.size() == 0) {
+		return robin_hood::unordered_node_map<uint64_t, std::vector<unsigned char>>();
+	}
+
+	uint64_t index_width = crackle::lib::compute_byte_width((sx+1) * (sy+1));
+
+	std::vector<uint64_t> nodes = read_boc_index(code, sx, sy);
+	uint32_t index_size = 4 + crackle::lib::ctoid(code, 0, 4);
+
+	std::vector<uint8_t> codepoints;
+	codepoints.reserve(4 * (code.size() - index_size));
+
+	for (uint64_t i = index_size; i < code.size(); i++) {
+		for (uint64_t j = 0; j < 4; j++) {
+			uint8_t codepoint = static_cast<uint8_t>((code[i] >> (2*j)) & 0b11);
+			codepoints.push_back(codepoint);
+		}
+	}
+
+	return codepoints_to_symbols(nodes, codepoints);
 }
 
 std::vector<uint8_t> decode_permissible_crack_code(

--- a/src/crackcodes.hpp
+++ b/src/crackcodes.hpp
@@ -607,7 +607,7 @@ codepoints_to_symbols(
 	for (uint64_t i = 0; i < codepoints.size(); i++) {
 		if (branches_taken == 0) {
 			if (node_i >= sorted_nodes.size()) {
-				throw std::runtime_error("corrupted crack code.");
+				break;
 			}
 			node = sorted_nodes[node_i];
 			node_i++;
@@ -625,9 +625,6 @@ codepoints_to_symbols(
 			) {
 				symbols.back() = 't';
 				branches_taken--;
-				if (branches_taken == 0) {
-					break;
-				}
 			}
 			else if (
 				(move == DirectionCode::DOWN && symbols.back() == 'u')

--- a/src/crackcodes.hpp
+++ b/src/crackcodes.hpp
@@ -538,10 +538,12 @@ std::vector<unsigned char> pack_codepoints(
 		}
 	}
 
-	for (uint64_t i = codepoints.size() - 1; i >= 1; i--) {
-		codepoints[i] -= codepoints[i-1];
-		if (codepoints[i] > 3) {
-			codepoints[i] += 4;
+	if (codepoints.size() > 0) {
+		for (uint64_t i = codepoints.size() - 1; i >= 1; i--) {
+			codepoints[i] -= codepoints[i-1];
+			if (codepoints[i] > 3) {
+				codepoints[i] += 4;
+			}
 		}
 	}
 

--- a/src/crackcodes.hpp
+++ b/src/crackcodes.hpp
@@ -516,12 +516,12 @@ create_crack_codes(
 
   auto codepoint_chains = symbols_to_codepoints(chains);
   for (auto& [node, codepoints] : codepoint_chains) {
-  		for (uint64_t i = codepoints.size() - 1; i >= 1; i--) {
-  			codepoints[i] -= codepoints[i-1];
-  			if (codepoints[i] > 3) {
-  				codepoints[i] += 4;
-  			}
-  		}
+		for (uint64_t i = codepoints.size() - 1; i >= 1; i--) {
+			codepoints[i] -= codepoints[i-1];
+			if (codepoints[i] > 3) {
+				codepoints[i] += 4;
+			}
+		}
   }
 
   return codepoint_chains;
@@ -663,7 +663,6 @@ std::vector<uint8_t> unpack_codepoints(
 		return std::vector<uint8_t>();
 	}
 
-	// std::vector<uint64_t> nodes = read_boc_index(code, sx, sy);
 	uint32_t index_size = 4 + crackle::lib::ctoid(code, 0, 4);
 
 	std::vector<uint8_t> codepoints;
@@ -676,13 +675,13 @@ std::vector<uint8_t> unpack_codepoints(
 		}
 	}
 	for (uint64_t i = 1; i < codepoints.size(); i++) {
-		codepoints[i] += codepoints[i+1];
+		codepoints[i] += codepoints[i-1];
 		if (codepoints[i] > 3) {
 			codepoints[i] -= 4;
 		}
 	}
 
-	return codepoints; // codepoints_to_symbols(nodes, codepoints);
+	return codepoints;
 }
 
 std::vector<uint8_t> decode_permissible_crack_code(

--- a/src/crackcodes.hpp
+++ b/src/crackcodes.hpp
@@ -540,27 +540,23 @@ std::vector<unsigned char> pack_codepoints(
 
 	std::vector<unsigned char> binary = write_boc_index(nodes, sx, sy);
 
+	uint8_t encoded = 0;
+	int pos = 0;
 	for (uint64_t node : nodes) {
 		auto chain = chains[node];
-		uint64_t all_moves = chain.size();
-		all_moves -= (all_moves % 4);
-
-		uint64_t i = 0;
-		uint8_t encoded = 0;
-		while (i < all_moves) {
-			encoded = 0;
-			for (uint64_t j = 0; j < 4; j++, i++) {
-				encoded |= (chain[i] << (2*j));
+		
+		for (uint64_t i = 0; i < chain.size(); i++) {
+			encoded |= (chain[i] << pos);
+			pos += 2;
+			if (pos == 8) {
+				binary.push_back(encoded);
+				encoded = 0;
+				pos = 0;
 			}
-			binary.push_back(encoded);
 		}
-		if (i < chain.size()) {
-			encoded = 0;
-			for (uint64_t j = 0; i < chain.size(); j++, i++) {
-				encoded |= (chain[i] << (2*j));
-			}
-			binary.push_back(encoded);
-		}
+	}
+	if (pos > 0) {
+		binary.push_back(encoded);
 	}
 
 	return binary;

--- a/src/crackcodes.hpp
+++ b/src/crackcodes.hpp
@@ -14,10 +14,10 @@ namespace crackle {
 namespace crackcodes {
 
 enum DirectionCode {
-	LEFT = 0b10,
+	LEFT = 0b11,
 	RIGHT = 0b01,
 	UP = 0b00,
-	DOWN = 0b11
+	DOWN = 0b10
 };
 
 inline std::pair<int64_t, int64_t> mkedge(int64_t a, int64_t b){

--- a/src/crackcodes.hpp
+++ b/src/crackcodes.hpp
@@ -600,7 +600,7 @@ codepoints_to_symbols(
 	uint64_t branches_taken = 0;
 	uint64_t node = 0;
 
-	char remap[4] = { 'u', 'r', 'l', 'd' };
+	char remap[4] = { 'u', 'r', 'd', 'l' };
 
 	uint64_t node_i = 0;
 

--- a/src/crackcodes.hpp
+++ b/src/crackcodes.hpp
@@ -528,7 +528,7 @@ create_crack_codes(
 }
 
 std::vector<unsigned char> pack_codepoints(
-	const robin_hood::unordered_node_map<uint64_t, std::vector<uint8_t>>& chains,
+	robin_hood::unordered_node_map<uint64_t, std::vector<uint8_t>>& chains,
 	const uint64_t sx, const uint64_t sy
 ) {
 
@@ -541,7 +541,7 @@ std::vector<unsigned char> pack_codepoints(
 	std::vector<unsigned char> binary = write_boc_index(nodes, sx, sy);
 
 	for (uint64_t node : nodes) {
-		auto& chain = chains[node];
+		auto chain = chains[node];
 		uint64_t all_moves = chain.size();
 		all_moves -= (all_moves % 4);
 
@@ -595,7 +595,7 @@ codepoints_to_symbols(
 	robin_hood::unordered_node_map<uint64_t, std::vector<unsigned char>> chains;
 
 	std::vector<unsigned char> symbols;
-	symbols.reserve(code.size() * 4 * 2);
+	symbols.reserve(codepoints.size() * 4 * 2);
 
 	uint64_t branches_taken = 0;
 	uint64_t node = 0;
@@ -606,17 +606,19 @@ codepoints_to_symbols(
 
 	for (uint64_t i = 0; i < codepoints.size(); i++) {
 		if (branches_taken == 0) {
-			if (node_i >= nodes.size()) {
+			if (node_i >= sorted_nodes.size()) {
 				throw std::runtime_error("corrupted crack code.");
 			}
-			node = nodes[node_i];
+			node = sorted_nodes[node_i];
 			node_i++;
 			i--; // b/c i will be incremented
 			branches_taken = 1;
 			continue;
 		}
 
-		if (symbols.size()) {
+		auto move = codepoints[i];
+
+		if (symbols.size()) {			
 			if (
 				(move == DirectionCode::UP && symbols.back() == 'd')
 				|| (move == DirectionCode::LEFT && symbols.back() == 'r')

--- a/src/crackle.hpp
+++ b/src/crackle.hpp
@@ -272,7 +272,7 @@ std::vector<std::vector<uint8_t>> decode_markov_model(
 		binary.begin() + model_offset,
 		binary.begin() + model_offset + header.markov_model_bytes()
 	);
-	return crackle::markov::from_stored_model(stored_model);
+	return crackle::markov::from_stored_model(stored_model, header.markov_model_order);
 }
 
 template <typename CCL>

--- a/src/crackle.hpp
+++ b/src/crackle.hpp
@@ -87,7 +87,7 @@ std::vector<unsigned char> compress_helper(
 
 	if (header.markov_model_order > 0) {
 		bool empty_cracks = true;
-		for (auto& code : crack_codes) {
+		for (auto& code : crack_codepoints) {
 			if (code.size()) {
 				empty_cracks = false;
 				break;
@@ -106,7 +106,10 @@ std::vector<unsigned char> compress_helper(
 		stored_model = crackle::markov::to_stored_model(model);
 
 		for (uint64_t z = 0; z < crack_codepoints.size(); z++) {
-			crack_codes[z] = crackle::markov::compress(crack_codepoints[z], model, header.markov_model_order);
+			crack_codes[z] = crackle::markov::compress(
+				crack_codepoints[z], model, header.markov_model_order,
+				sx, sy
+			);
 		}
 	}
 	else {
@@ -293,7 +296,7 @@ std::vector<CCL> crack_codes_to_cc_labels(
 		std::vector<uint64_t> nodes = crackle::crackcodes::read_boc_index(code, sx, sy);
 
 		std::vector<uint8_t> codepoints;
-		if (header.markov_model_order == 0) {
+		if (markov_model.size() == 0) {
 			codepoints = crackle::crackcodes::unpack_codepoints(code, sx, sy);
 		}
 		else {
@@ -370,8 +373,7 @@ LABEL* decompress(
 	auto crack_codes = get_crack_codes(header, binary, z_start, z_end);
 	uint64_t N = 0;
 	std::vector<uint32_t> cc_labels = crack_codes_to_cc_labels<uint32_t>(
-		header, crack_codes, 
-		header.sx, header.sy, szr, 
+		crack_codes, header.sx, header.sy, szr, 
 		/*permissible=*/(header.crack_format == CrackFormat::PERMISSIBLE), 
 		/*N=*/N,
 		/*markov_model*/markov_model

--- a/src/crackle.hpp
+++ b/src/crackle.hpp
@@ -69,7 +69,8 @@ std::vector<unsigned char> compress_helper(
 		/*grid_size*/2147483648,
 		
 		/*num_label_bytes=*/0,
-		/*fortran_order*/fortran_order
+		/*fortran_order*/fortran_order,
+		/*markov_model_order=*/0, // 0 is disabled
 	);
 
 	if (voxels == 0) {
@@ -116,6 +117,9 @@ std::vector<unsigned char> compress_helper(
 	final_binary.insert(final_binary.end(), header_binary.begin(), header_binary.end());
 	final_binary.insert(final_binary.end(), z_index_binary.begin(), z_index_binary.end());
 	final_binary.insert(final_binary.end(), labels_binary.begin(), labels_binary.end());
+	if (header.markov_model_order > 0) {
+		// markov model goes here
+	}
 	for (auto& code : crack_codes) {
 		final_binary.insert(final_binary.end(), code.begin(), code.end());
 	}

--- a/src/fastcrackle.cpp
+++ b/src/fastcrackle.cpp
@@ -67,7 +67,8 @@ template <typename LABEL>
 py::bytes compress_helper(
 	const py::array &labels, 
 	const bool allow_pins = false,
-	const bool fortran_order = true
+	const bool fortran_order = true,
+	const uint64_t markov_model_order = 0
 ) {
 	const uint64_t sx = labels.shape()[0];
 	const uint64_t sy = labels.shape()[1];
@@ -77,7 +78,8 @@ py::bytes compress_helper(
 		reinterpret_cast<LABEL*>(const_cast<void*>(labels.data())),
 		sx, sy, sz,
 		allow_pins,
-		fortran_order
+		fortran_order,
+		markov_model_order
 	);
 	return py::bytes(reinterpret_cast<char*>(buf.data()), buf.size());
 }
@@ -85,37 +87,54 @@ py::bytes compress_helper(
 py::bytes compress(
 	const py::array &labels, 
 	const bool allow_pins = false,
-	const bool fortran_order = true
+	const bool fortran_order = true,
+	const uint64_t markov_model_order = 0
 ) {
 	int width = labels.dtype().itemsize();
 	bool is_signed = labels.dtype().kind() == 'i';
 
 	if (is_signed) {
 		if (width == 1) {
-			return compress_helper<int8_t>(labels, allow_pins, fortran_order);
+			return compress_helper<int8_t>(
+				labels, allow_pins, fortran_order, markov_model_order
+			);
 		}
 		else if (width == 2) {
-			return compress_helper<int16_t>(labels, allow_pins, fortran_order);
+			return compress_helper<int16_t>(
+				labels, allow_pins, fortran_order, markov_model_order
+			);
 		}
 		else if (width == 4) {
-			return compress_helper<int32_t>(labels, allow_pins, fortran_order);
+			return compress_helper<int32_t>(
+				labels, allow_pins, fortran_order, markov_model_order
+			);
 		}
 		else {
-			return compress_helper<int64_t>(labels, allow_pins, fortran_order);
+			return compress_helper<int64_t>(
+				labels, allow_pins, fortran_order, markov_model_order
+			);
 		}
 	}
 	else {
 		if (width == 1) {
-			return compress_helper<uint8_t>(labels, allow_pins, fortran_order);
+			return compress_helper<uint8_t>(
+				labels, allow_pins, fortran_order, markov_model_order
+			);
 		}
 		else if (width == 2) {
-			return compress_helper<uint16_t>(labels, allow_pins, fortran_order);
+			return compress_helper<uint16_t>(
+				labels, allow_pins, fortran_order, markov_model_order
+			);
 		}
 		else if (width == 4) {
-			return compress_helper<uint32_t>(labels, allow_pins, fortran_order);
+			return compress_helper<uint32_t>(
+				labels, allow_pins, fortran_order, markov_model_order
+			);
 		}
 		else {
-			return compress_helper<uint64_t>(labels, allow_pins, fortran_order);
+			return compress_helper<uint64_t>(
+				labels, allow_pins, fortran_order, markov_model_order
+			);
 		}
 	}
 }

--- a/src/header.hpp
+++ b/src/header.hpp
@@ -45,6 +45,7 @@ public:
 	uint32_t grid_size;
 	uint32_t num_label_bytes;
 	bool fortran_order;
+	uint8_t markov_model_order;
 
 	CrackleHeader() :
 		format_version(0),
@@ -53,7 +54,8 @@ public:
 		is_signed(false),
 		data_width(1), stored_data_width(1),
 		sx(1), sy(1), sz(1), grid_size(2147483648),
-		num_label_bytes(0), fortran_order(true)
+		num_label_bytes(0), fortran_order(true),
+		markov_model_order(0)
 	{}
 
 	CrackleHeader(
@@ -66,7 +68,8 @@ public:
 		const uint32_t _sx, const uint32_t _sy, const uint32_t _sz,
 		const uint32_t _grid_size,
 		const uint32_t _num_label_bytes,
-		const bool _fortran_order
+		const bool _fortran_order,
+		const bool _markov_model_order
 	) : 
 		format_version(_format_version),
 		label_format(_label_fmt),
@@ -76,7 +79,8 @@ public:
 		sx(_sx), sy(_sy), sz(_sz),
 		grid_size(_grid_size),
 		num_label_bytes(_num_label_bytes), 
-		fortran_order(_fortran_order)
+		fortran_order(_fortran_order), 
+		markov_model_order(_markov_model_order)
 	{}
 
 	void assign_from_buffer(const unsigned char* buf) {
@@ -102,6 +106,7 @@ public:
 		label_format = static_cast<LabelFormat>((format_bytes & 0b01100000) >> 5);
 		fortran_order = static_cast<bool>((format_bytes & 0b10000000) >> 7);
 		is_signed = static_cast<bool>((format_bytes >> 8) & 0b1);
+		markov_model_order = static_cast<uint8_t>((format_bytes >> 9) & 0b1111);
 	}
 
 	CrackleHeader(const unsigned char* buf) {
@@ -153,6 +158,7 @@ public:
 		format_bytes |= static_cast<uint16_t>(label_format) << 5;
 		format_bytes |= static_cast<uint16_t>(fortran_order) << 7;
 		format_bytes |= static_cast<uint16_t>(is_signed) << 8;
+		format_bytes |= static_cast<uint16_t>((markov_model_order & 0b1111) << 9);
 
 		i += lib::itoc(format_version, buf, i);
 		i += lib::itoc(format_bytes, buf, i);

--- a/src/header.hpp
+++ b/src/header.hpp
@@ -186,6 +186,13 @@ public:
 		);
 	}
 
+	uint64_t markov_model_bytes() const {
+		if (markov_model_order == 0) {
+			return 0;
+		}
+		return pow(4, std::min(markov_model_order, 15));
+	}
+
 	static bool valid_header(unsigned char* buf) {
 		bool valid_magic = (buf[0] == 'c' && buf[1] == 'r' && buf[2] == 'k' && buf[3] == 'l');
 		uint8_t format_version = buf[4];

--- a/src/header.hpp
+++ b/src/header.hpp
@@ -190,7 +190,12 @@ public:
 		if (markov_model_order == 0) {
 			return 0;
 		}
-		return pow(4, std::min(markov_model_order, 15));
+		return pow(4, 
+			std::min(
+				static_cast<uint64_t>(markov_model_order), 
+				static_cast<uint64_t>(15)
+			)
+		);
 	}
 
 	static bool valid_header(unsigned char* buf) {

--- a/src/header.hpp
+++ b/src/header.hpp
@@ -69,7 +69,7 @@ public:
 		const uint32_t _grid_size,
 		const uint32_t _num_label_bytes,
 		const bool _fortran_order,
-		const bool _markov_model_order
+		const uint8_t _markov_model_order
 	) : 
 		format_version(_format_version),
 		label_format(_label_fmt),

--- a/src/header.hpp
+++ b/src/header.hpp
@@ -190,12 +190,15 @@ public:
 		if (markov_model_order == 0) {
 			return 0;
 		}
-		return pow(4, 
+		uint64_t model_size = pow(4, 
 			std::min(
 				static_cast<uint64_t>(markov_model_order), 
 				static_cast<uint64_t>(15)
 			)
 		);
+		// model is packed so only 5 bits are used
+		// for each row. Round up.
+		return ((model_size * 5) + 4) / 8;
 	}
 
 	static bool valid_header(unsigned char* buf) {

--- a/src/lib.hpp
+++ b/src/lib.hpp
@@ -173,7 +173,7 @@ std::vector<unsigned char> write_packed_bitstream(
 
 std::vector<uint8_t> read_packed_bitstream(
 	const std::vector<unsigned char>& bitstream, 
-	const int bits, const int n_fields
+	const uint64_t bits, const uint64_t n_fields
 ) {
 
 	std::vector<uint8_t> output(n_fields);
@@ -191,7 +191,7 @@ std::vector<uint8_t> read_packed_bitstream(
 			j++;
 		}
 		else {
-			int read = 8 - pos;
+			uint64_t read = 8 - pos;
 			output[i] |= (bitstream[j] >> pos);
 			j++;
 			output[i] |= (bitstream[j] << (8-(bits-read)) >> (8-(bits-read)));

--- a/src/lib.hpp
+++ b/src/lib.hpp
@@ -134,6 +134,13 @@ uint64_t ctoid(
 	return val;
 }
 
+uint64_t ctoid(
+	const std::vector<unsigned char>& buf,
+	const uint64_t idx, const int byte_width
+) {
+	return ctoid(buf.data(), idx, byte_width);
+}
+
 // bits must be < 8
 // data must be <= 1 byte
 std::vector<unsigned char> write_packed_bitstream(

--- a/src/markov.hpp
+++ b/src/markov.hpp
@@ -178,6 +178,39 @@ namespace markov {
 		return data_stream;
 	}
 
+	std::vector<unsigned char> to_stored_model(
+		const std::vector<std::vector<uint8_t>>& model
+	) {
+		std::vector<unsigned char> stored_model(model.size());
+
+		for (uint64_t i = 0; i < model.size(); i++) {
+			stored_model[i] = (
+				  (model[i] & 0b11)
+				| ((model[i] >> 2) & 0b11)
+				| ((model[i] >> 4) & 0b11)
+				| ((model[i] >> 6) & 0b11)
+			);
+		}
+
+		return stored_model;
+	}
+
+	std::vector<std::vector<uint8_t>> from_stored_model(
+		const std::vector<unsigned char>& model_stream
+	) {
+		std::vector<std::vector<uint8_t>> model(model_stream.size());
+
+		for (uint64_t i = 0; i < model_stream.size(); i++) {
+			model[i].resize(4);
+			model[i][0] = model_stream[i] & 0b11;
+			model[i][1] = (model_stream[i] >> 2) & 0b11;
+			model[i][2] = (model_stream[i] >> 4) & 0b11;
+			model[i][3] = (model_stream[i] >> 6) & 0b11;
+		}
+
+		return model;
+	}
+	
 	std::vector<unsigned char> encode_markov(
 		std::vector<std::vector<unsigned char>> &crack_codes,
 		std::vector<robin_hood::unordered_flat_map<int,int>>& stats,

--- a/src/markov.hpp
+++ b/src/markov.hpp
@@ -168,6 +168,8 @@ namespace markov {
 					data_stream.push_back(model[model_row][3]);
 					pos += 3;
 				}
+
+				buf.push_back(data_stream.back());
 			}
 
 			pos -= 8;

--- a/src/markov.hpp
+++ b/src/markov.hpp
@@ -1,0 +1,92 @@
+#ifndef __MARKOV_HXX__
+#define __MARKOV_HXX__
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+#include <type_traits>
+
+#include "robin_hood.hpp"
+
+namespace crackle {
+namespace markov {
+
+	struct CircularBuf {
+		uint8_t* data;
+		int length;
+		int idx;
+
+		CircularBuf(int model_order) {
+			data = new uint8_t[model_order]();
+			length = model_order;
+			idx = 0;
+		}
+
+		~CircularBuf() {
+			delete [] data;
+		}
+
+		void push_back(uint8_t elem) {
+			data[idx] = elem;
+			idx++;
+			if (idx >= length) {
+				idx = 0;
+			}
+		}
+
+		std::vector<uint8_t> read() {
+			std::vector<uint8_t> out;
+			out.reserve(length);
+			for (int i = 0, j = idx; i < length; i++, j++) {
+				if (j >= length) {
+					j = 0;
+				}
+				out.push_back(data[j]);
+			}
+			return out;
+		}
+
+		int change_to_base_10() {
+			int base_10 = 0;
+			for (int i = 0, j = idx; i < length; i++, j++) {
+				if (j >= length) {
+					j = 0;
+				}
+				base_10 += pow(4, i) * static_cast<int>(input[j]);
+			}
+			return base_10;
+		}
+	}
+
+	std::vector<robin_hood::unordered_flat_map<int,int>> 
+	gather_statistics(
+		std::vector<std::vector<unsigned char>> &crack_codes,
+		int64_t model_order
+	) {
+		std::vector<robin_hood::unordered_flat_map<int,int>> stats(
+			pow(4, model_order)
+		);
+		CircularBuf buf(model_order);
+
+		// might be an off-by-one here
+		for (auto codes : crack_codes) {
+			for (int64_t i = 0; i < codes.size() - model_order; i++) {
+				buf.push_back(code[i]);
+				int idx = buf.change_to_base_10();
+				stats[idx][code[i]]++;
+			}
+		}
+
+		return stats;
+	}
+
+	
+
+};
+};
+
+#endif

--- a/src/markov.hpp
+++ b/src/markov.hpp
@@ -280,9 +280,9 @@ namespace markov {
 	}
 
 
-	std::vector<uint8_t> decompress(
+	std::vector<std::vector<uint8_t>> decompress(
 		const std::vector<unsigned char>& stored_model,
-		const std::vector<std::vector<unsigned char>>& markov_crack_codes
+		std::vector<std::vector<unsigned char>>& markov_crack_codes
 	) {
 		auto model = from_stored_model(stored_model);
 

--- a/src/markov.hpp
+++ b/src/markov.hpp
@@ -14,6 +14,25 @@
 
 namespace crackle {
 namespace markov {
+	// Lookup tables are generated from the following python code:
+	/*
+		from itertools import permutations
+		LUT = []
+		for p in list(permutations([0,1,2,3])):
+		    val = 0
+		    for i in range(4):
+		        val |= p[i] << 2*i
+		    LUT.append(val)
+
+		for x in LUT:
+			print(bin(x))
+		
+		ILUT = [255] * 255
+		for i, el in enumerate(LUT):
+			ILUT[el] = i
+
+		print(ILUT)
+	*/
 
 	// lookup tables for translating
 	// the 24 possible UDLR positions

--- a/src/markov.hpp
+++ b/src/markov.hpp
@@ -242,11 +242,11 @@ namespace markov {
 				pos++;
 			}
 			else if (idx == 1) {
-				byte |= (0b10 << pos);
+				byte |= (0b01 << pos);
 				pos += 2;
 			}
 			else if (idx == 2) {
-				byte |= (0b110 << pos);
+				byte |= (0b011 << pos);
 				pos += 3;
 			}
 			else {

--- a/src/markov.hpp
+++ b/src/markov.hpp
@@ -62,12 +62,25 @@ namespace markov {
 		}
 	}
 
-	std::vector<robin_hood::unordered_flat_map<int,int>> 
+	void apply_difference_code(
+		std::vector<std::vector<uint64_t>>& crack_codes,
+	) {
+		for (auto code : crack_codes) {
+			for (uint64_t i = code.size() - 1; i >= 1; i--) {
+				code[i] -= code[i-1];
+				if (code[i] > 3) {
+					code += 4;
+				}
+			}
+		}
+	}
+
+	std::vector<robin_hood::unordered_flat_map<uint8_t,int>> 
 	gather_statistics(
 		std::vector<std::vector<unsigned char>> &crack_codes,
 		int64_t model_order
 	) {
-		std::vector<robin_hood::unordered_flat_map<int,int>> stats(
+		std::vector<robin_hood::unordered_flat_map<uint8_t,int>> stats(
 			pow(4, model_order)
 		);
 		CircularBuf buf(model_order);
@@ -75,7 +88,7 @@ namespace markov {
 		// might be an off-by-one here
 		for (auto codes : crack_codes) {
 			for (int64_t i = 0; i < codes.size() - model_order; i++) {
-				buf.push_back(code[i]);
+				buf.push_back(static_cast<uint8_t>(code[i]));
 				int idx = buf.change_to_base_10();
 				stats[idx][code[i]]++;
 			}
@@ -84,8 +97,136 @@ namespace markov {
 		return stats;
 	}
 
-	
+	std::vector<std::vector<uint8_t>> stats_to_model(
+		std::vector<robin_hood::unordered_flat_map<int,int>>& stats,
+	) {
+		struct {
+			bool operator()(
+				std::pair<int,int>& a, std::pair<int,int>& b
+			) const { 
+				return a.second >= b.second;
+			}
+		} CmpIndex;
 
+		std::vector<std::vector<uint8_t>> model(stats.size());
+		for (uint64_t i = 0; i < model.size(); i++) {
+			std::vector<std::pair<int,int>> pair_row(stats[i].begin(), stats[i].end());
+			// most frequent in lowest index
+			std::sort(pair_row.begin(), pair_row.end(), CmpIndex);
+			std::vector<uint8_t> row(4);
+			for (int j = 0; j < 4; j++) {
+				row[pair_row[j].first] = j;
+			}
+			model[i] = std::move(row);
+		}
+
+		return model;
+	}
+
+	std::vector<uint8_t> decode_markov(
+		std::vector<unsigned char>& crack_code,
+		std::vector<std::vector<uint8_t>>& model
+	) {
+		std::vector<uint8_t> data_stream;
+
+		int model_order = static_cast<int>(log2(model.size()) / log2(4));
+		CircularBuf buf(model_order);
+
+		int pos = 2;
+		uint8_t start_dir = crack_code[0] & 0b11;
+		data_stream.push_back(start_dir);
+		buf.push_back(start_dir);
+
+		for (uint64_t i = 0; i < crack_code.size(); i++) {
+			uint16_t byte = crack_code[i]; 
+			if (i < crack_code.size() - 1) {
+				byte |= (crack_code[i+1] << 8);
+			}
+
+			while (pos < 8) {
+				uint8_t codepoint = (byte >> pos) & 0b111;
+				uint64_t model_row = buf.change_to_base_10();
+
+				if ((codepoint & 0b1) == 0) {
+					data_stream.push_back(model[model_row][0]);
+					pos++;
+				}
+				else if ((codepoint & 0b10) == 0) {
+					data_stream.push_back(model[model_row][1]);
+					pos += 2;
+				}
+				else if ((codepoint & 0b100) == 0) {
+					data_stream.push_back(model[model_row][2]);	
+					pos += 3;
+				}
+				else {
+					data_stream.push_back(model[model_row][3]);
+					pos += 3;
+				}
+			}
+
+			pos -= 8;
+		}
+
+		for (uint64_t i = 1; i < data_stream.size(); i++) {
+			data_stream[i] += data_stream[i-1];
+			if (data_stream[i] > 3) {
+				data_stream[i] -= 4;
+			}
+		}
+
+		return data_stream;
+	}
+
+	std::vector<unsigned char> encode_markov(
+		std::vector<std::vector<unsigned char>> &crack_codes,
+		std::vector<robin_hood::unordered_flat_map<int,int>>& stats,
+		int64_t model_order
+	) {
+		std::vector<unsigned char> bitstream;
+		auto model = stats_to_model(stats);
+
+		CircularBuf buf(model_order);
+
+		for (auto code : crack_codes) {
+			int pos = 2;
+			uint16_t byte = code[0];
+
+			buf.push_back(code[0]);
+			for (uint64_t i = 1; i < code.size(); i++) {
+				uint8_t idx = model[buf.change_to_base_10()][code[i]];
+
+				if (idx == 0) {
+					pos++;
+				}
+				else if (idx == 1) {
+					byte |= (0b10 << pos);
+					pos += 2;
+				}
+				else if (idx == 2) {
+					byte |= (0b110 << pos);
+					pos += 3;
+				}
+				else {
+					byte |= (0b111 << pos);
+					pos += 3;
+				}
+
+				if (pos >= 8) {
+					bitstream.push_back(static_cast<uint8_t>(byte));
+					pos -= 8;
+					byte >>= 8;
+				}
+
+				buf.push_back(code[i]);
+			}
+			if (pos > 0) {
+				bitstream.push_back(static_cast<uint8_t>(byte));
+			}
+		}
+
+		return bitstream;
+	}
 };
 };
 

--- a/src/markov.hpp
+++ b/src/markov.hpp
@@ -38,7 +38,7 @@ namespace markov {
 			}
 		}
 
-		std::vector<uint8_t> read() {
+		std::vector<uint8_t> read() const {
 			std::vector<uint8_t> out;
 			out.reserve(length);
 			for (int i = 0, j = idx; i < length; i++, j++) {
@@ -50,26 +50,26 @@ namespace markov {
 			return out;
 		}
 
-		int change_to_base_10() {
+		int change_to_base_10() const {
 			int base_10 = 0;
 			for (int i = 0, j = idx; i < length; i++, j++) {
 				if (j >= length) {
 					j = 0;
 				}
-				base_10 += pow(4, i) * static_cast<int>(input[j]);
+				base_10 += pow(4, i) * static_cast<int>(data[j]);
 			}
 			return base_10;
 		}
-	}
+	};
 
 	void apply_difference_code(
-		std::vector<std::vector<uint64_t>>& crack_codes,
+		std::vector<std::vector<uint64_t>>& crack_codes
 	) {
 		for (auto code : crack_codes) {
 			for (uint64_t i = code.size() - 1; i >= 1; i--) {
 				code[i] -= code[i-1];
 				if (code[i] > 3) {
-					code += 4;
+					code[i] += 4;
 				}
 			}
 		}
@@ -77,8 +77,8 @@ namespace markov {
 
 	std::vector<robin_hood::unordered_flat_map<uint8_t,int>> 
 	gather_statistics(
-		std::vector<std::vector<unsigned char>> &crack_codes,
-		int64_t model_order
+		const std::vector<std::vector<uint64_t>> &crack_codes,
+		const int64_t model_order
 	) {
 		std::vector<robin_hood::unordered_flat_map<uint8_t,int>> stats(
 			pow(4, model_order)
@@ -86,7 +86,7 @@ namespace markov {
 		CircularBuf buf(model_order);
 
 		// might be an off-by-one here
-		for (auto codes : crack_codes) {
+		for (auto code : crack_codes) {
 			for (int64_t i = 0; i < codes.size() - model_order; i++) {
 				buf.push_back(static_cast<uint8_t>(code[i]));
 				int idx = buf.change_to_base_10();
@@ -98,7 +98,7 @@ namespace markov {
 	}
 
 	std::vector<std::vector<uint8_t>> stats_to_model(
-		std::vector<robin_hood::unordered_flat_map<int,int>>& stats,
+		std::vector<robin_hood::unordered_flat_map<int,int>>& stats
 	) {
 		struct {
 			bool operator()(
@@ -278,7 +278,7 @@ namespace markov {
 
 	std::vector<uint8_t> decompress(
 		const std::vector<unsigned char>& stored_model,
-		const std::vector<unsigned char>& markov_crack_codes
+		const std::vector<std::vector<unsigned char>>& markov_crack_codes
 	) {
 		auto model = from_stored_model(stored_model);
 

--- a/src/markov.hpp
+++ b/src/markov.hpp
@@ -106,8 +106,21 @@ namespace markov {
 			// most frequent in lowest index
 			std::sort(pair_row.begin(), pair_row.end(), CmpIndex);
 			std::vector<uint8_t> row(4);
-			for (int j = 0; j < 4; j++) {
+			std::vector<bool> marked(4);
+			int j = 0;
+			for (j = 0; j < pair_row.size(); j++) {
 				row[pair_row[j].first] = j;
+				marked[pair_row[j].first] = true;
+			}
+			// handle sparse statistics
+			if (j < 4) {
+				for (int k = 0; k < 4; k++) {
+					if (marked[k]) {
+						continue;
+					}
+					row[k] = j;
+					j++;
+				}
 			}
 			model[i] = std::move(row);
 		}

--- a/src/markov.hpp
+++ b/src/markov.hpp
@@ -65,7 +65,7 @@ namespace markov {
 	std::vector<robin_hood::unordered_flat_map<uint8_t,int>> 
 	gather_statistics(
 		const std::vector<robin_hood::unordered_node_map<uint64_t, std::vector<uint8_t>>> &crack_codes,
-		const int64_t model_order
+		const uint64_t model_order
 	) {
 		std::vector<robin_hood::unordered_flat_map<uint8_t,int>> stats(
 			pow(4, model_order)
@@ -74,7 +74,7 @@ namespace markov {
 		for (auto slice : crack_codes) {
 			for (auto& [node, code] : slice) {
 				CircularBuf buf(model_order);
-				for (int64_t i = 0; i < code.size() - model_order; i++) {
+				for (uint64_t i = 0; i < code.size() - model_order; i++) {
 					buf.push_back(static_cast<uint8_t>(code[i]));
 					int idx = buf.change_to_base_10();
 					stats[idx][code[i]]++;
@@ -110,14 +110,14 @@ namespace markov {
 			std::sort(pair_row.begin(), pair_row.end(), CmpIndex);
 			std::vector<uint8_t> row(4);
 			std::vector<bool> marked(4);
-			int j = 0;
+			uint64_t j = 0;
 			for (j = 0; j < pair_row.size(); j++) {
 				row[pair_row[j].first] = j;
 				marked[pair_row[j].first] = true;
 			}
 			// handle sparse statistics
 			if (j < 4) {
-				for (int k = 0; k < 4; k++) {
+				for (uint64_t k = 0; k < 4; k++) {
 					if (marked[k]) {
 						continue;
 					}

--- a/src/markov.hpp
+++ b/src/markov.hpp
@@ -53,7 +53,8 @@ namespace markov {
 		int push_back_and_update(uint8_t elem) {
 			base_10_cached -= front();
 			base_10_cached >>= 2;
-			base_10_cached += static_cast<int>(elem) * pow(4,length-1);
+			// 4^(len-1) = 2^2^(len-1) = 2^(2 * (len-1))
+			base_10_cached += static_cast<int>(elem) * (1 << (2 * (length-1)));
 			push_back(elem);
 			return base_10_cached;
 		}

--- a/src/markov.hpp
+++ b/src/markov.hpp
@@ -320,12 +320,14 @@ namespace markov {
 			}
 			std::sort(decode_row.begin(), decode_row.end(), CmpValue);
 
-			int model_idx = ILUT[(
+			unsigned int model_key = (
 				  (decode_row[0].first & 0b11)
 				| ((decode_row[1].first & 0b11) << 2)
 				| ((decode_row[2].first & 0b11) << 4)
 				| ((decode_row[3].first & 0b11) << 6)
-			)];
+			);
+
+			int model_idx = ILUT[model_key];
 
 			if (model_idx == DNE) {
 				throw std::runtime_error("Corrupted model.");
@@ -364,7 +366,7 @@ namespace markov {
 				int decoded = 0;
 				if (pos + 5 > 8 && i < stream_size - 1) {
 					decoded = (model_stream[i] >> pos) & 0b11111;
-					decoded |= (model_stream[i+1] >> (pos + 5 - 8)) << (8 - pos);
+					decoded |= (model_stream[i+1] & ~(~0u << (pos + 5 - 8))) << (8 - pos);
 					decoded &= 0b11111;
 				}
 				else {

--- a/src/markov.hpp
+++ b/src/markov.hpp
@@ -62,6 +62,33 @@ namespace markov {
 		}
 	};
 
+	std::tuple<std::vector<uint64_t>, std::vector<uint8_t>> difference_codepoints(
+		robin_hood::unordered_node_map<uint64_t, std::vector<uint8_t>>& chains
+	) {
+		std::vector<uint64_t> nodes;
+		for (auto& [node, code] : chains) {
+			nodes.push_back(node);
+		}
+		std::sort(nodes.begin(), nodes.end());
+
+		std::vector<uint8_t> codepoints;
+		for (uint64_t node : nodes) {
+			auto chain = chains[node];
+			for (uint8_t codepoint : chain) {
+				codepoints.push_back(codepoint);
+			}
+		}
+		if (codepoints.size() > 0) {
+			for (uint64_t i = codepoints.size() - 1; i >= 1; i--) {
+				codepoints[i] -= codepoints[i-1];
+				if (codepoints[i] > 3) {
+					codepoints[i] += 4;
+				}
+			}
+		}
+		return std::make_tuple(nodes, codepoints);
+	}
+
 	std::vector<robin_hood::unordered_flat_map<uint8_t,int>> 
 	gather_statistics(
 		const std::vector<robin_hood::unordered_node_map<uint64_t, std::vector<uint8_t>>> &crack_codes,

--- a/src/markov.hpp
+++ b/src/markov.hpp
@@ -87,7 +87,7 @@ namespace markov {
 
 		// might be an off-by-one here
 		for (auto code : crack_codes) {
-			for (int64_t i = 0; i < codes.size() - model_order; i++) {
+			for (int64_t i = 0; i < code.size() - model_order; i++) {
 				buf.push_back(static_cast<uint8_t>(code[i]));
 				int idx = buf.change_to_base_10();
 				stats[idx][code[i]]++;
@@ -98,11 +98,11 @@ namespace markov {
 	}
 
 	std::vector<std::vector<uint8_t>> stats_to_model(
-		std::vector<robin_hood::unordered_flat_map<int,int>>& stats
+		std::vector<robin_hood::unordered_flat_map<uint8_t,int>>& stats
 	) {
 		struct {
 			bool operator()(
-				std::pair<int,int>& a, std::pair<int,int>& b
+				robin_hood::pair<uint8_t,int>& a, robin_hood::pair<uint8_t,int>& b
 			) const { 
 				return a.second >= b.second;
 			}
@@ -110,7 +110,11 @@ namespace markov {
 
 		std::vector<std::vector<uint8_t>> model(stats.size());
 		for (uint64_t i = 0; i < model.size(); i++) {
-			std::vector<std::pair<int,int>> pair_row(stats[i].begin(), stats[i].end());
+			std::vector<robin_hood::pair<uint8_t,int>> pair_row;
+			pair_row.reserve(4);
+			for (auto& pair : stats[i]) {
+				pair_row.push_back(pair);
+			}
 			// most frequent in lowest index
 			std::sort(pair_row.begin(), pair_row.end(), CmpIndex);
 			std::vector<uint8_t> row(4);
@@ -185,10 +189,10 @@ namespace markov {
 
 		for (uint64_t i = 0; i < model.size(); i++) {
 			stored_model[i] = (
-				  (model[i] & 0b11)
-				| ((model[i] >> 2) & 0b11)
-				| ((model[i] >> 4) & 0b11)
-				| ((model[i] >> 6) & 0b11)
+				  (model[i][0] & 0b11)
+				| ((model[i][1] & 0b11) << 2)
+				| ((model[i][2] & 0b11) << 4)
+				| ((model[i][3] & 0b11) << 6)
 			);
 		}
 


### PR DESCRIPTION
Adds finite context modeling of crack codes. Looks at N symbols of NSEW directions and uses the measured frequencies of symbols prior to encoding to save space by using the following code:

1. 0 - most frequent
2. 10 - 2nd most frequent
3. 110 - second least frequent
4. 111 - least frequent

If 1 > 3+4, then an overall space savings is achieved. 

The crack codes are difference coded to make them orientation independent, which seems to increase the frequency of the most frequent next position.

The model is stored as a bit packed UDLR (two bits per symbol) byte per a prediction field. These are then packed into 5 bits each by referencing a permutation lookup table. Saving space like this makes using higher order models more economical.

The size of the model (let O be the order of the model) is `4^O` bytes x 5 / 8. So for example a 5th order model is `1024 * 5 / 8 = 640 bytes`. 

Context modeling info is stored in the header. If the header bits indicate a 0 order model, no context modeling is used and all crack code bytes are literals. If modeling is used, then all crack codes are adaptive.

```python
crackle.compress(..., markov_model_order=O)
```

```bash
crackle FILE -m $ORDER (e.g. 5)
```

You can expect between a 5-20% improvement in size by using an appropriate model. There will be a moderate decrease in speed.

Finite context modeling can be used independent of pins. Used together, you can get even better compression.

This update also adjusts the BOC encoding to be as described in [Estes and Algazi (1995)](10.1109/DCC.1995.515502). This is necessary to make encoding the chains more clean. It slightly increases the BOC size right now, but later on a better encoder can use chain rotations to get better compression of the BOC index beyond what we had before.
