### PR TITLE
perf: optimize crack code creation

### DIFF
--- a/automated_test.py
+++ b/automated_test.py
@@ -22,7 +22,7 @@ def test_compress_decompress_random(dtype, markov_model_order):
   print(recovered.T)
   assert np.all(labels == recovered)
 
-  labels = np.random.randint(0,40,size=(1000,999,1), dtype=dtype)
+  labels = np.random.randint(0,40,size=(256,255,1), dtype=dtype)
   binary = crackle.compress(labels, markov_model_order=markov_model_order)
   recovered = crackle.decompress(binary)
   assert np.all(labels == recovered)

--- a/src/crackcodes.hpp
+++ b/src/crackcodes.hpp
@@ -416,7 +416,12 @@ create_crack_codes(
 						break;
 					}
 				}
-				continue;
+				if (node > -1) {
+					continue;
+				}
+				else {
+					break;
+				}
 			}
 			else if (neighbors.size() > 1) {
 				code.push_back('b');
@@ -666,7 +671,9 @@ void decode_permissible_crack_code(
 		for (unsigned char symbol : symbols) {
 			int64_t loc = x + sx * y;
 			if (loc < 0 || loc >= (sx+1) * (sy+1)) {
-				throw std::runtime_error("crackle: decode_permissible_crack_code: index out of range.");
+				std::string err = std::string("crackle: decode_permissible_crack_code: index out of range. loc: ");
+				err += std::to_string(loc);
+				throw std::runtime_error(err);
 			}
 
 			if (symbol == 'u') {

--- a/src/crackcodes.hpp
+++ b/src/crackcodes.hpp
@@ -207,22 +207,22 @@ symbols_to_codepoints(
 	return encoded_chains;
 }
 
-void remove_initial_branch(
-	int64_t& node,
+int64_t remove_initial_branch(
+	int64_t node,
 	std::vector<char>& code,
 	const int64_t sx, const int64_t sy
 ) {
 	if (code.empty()) {
-		return;
+		return node;
 	}
 	else if (code[0] != 'b') {
-		return;
+		return node;
 	}
 
 	int64_t i = 1;
 	while (code[i] != 't') {
 		if (code[i] == 'b') {
-			return;
+			return node;
 		}
 		i++;
 	}
@@ -263,7 +263,7 @@ void remove_initial_branch(
 		std::swap(code[i], code[last - i + 1]);
 	}
 
-	node = pos_x + sxe * pos_y;
+	return pos_x + sxe * pos_y;
 }
 
 std::vector<uint64_t> read_boc_index(
@@ -383,7 +383,6 @@ create_crack_codes(
 	int64_t start_node = 0;
 
 	while ((start_node = G.next_cluster(start_node)) != -1) {
-		printf("%d\n", start_node);
 		int64_t node = start_node;
 
 		std::vector<char> code;
@@ -457,9 +456,11 @@ create_crack_codes(
 			branches_taken--;
 		}
 
-		remove_initial_branch(start_node, code, sx, sy);
+		int64_t adjusted_start_node = remove_initial_branch(
+			start_node, code, sx, sy
+		);
 		chains.push_back(
-			std::make_pair(start_node, code)
+			std::make_pair(adjusted_start_node, code)
 		);
 	}
 

--- a/src/crackcodes.hpp
+++ b/src/crackcodes.hpp
@@ -82,7 +82,7 @@ struct Graph {
 	}
 
 	template <typename LABEL>
-	void init(
+	bool init(
 		const LABEL* labels,
 		const int64_t sx, const int64_t sy,
 		const bool permissible
@@ -91,6 +91,8 @@ struct Graph {
 		sye = sy + 1; // sy edges
 
 		adjacency.resize(sxe * sye);
+
+		bool any_edges = false;
 
 		if (permissible) {
 			// assign vertical edges
@@ -101,6 +103,7 @@ struct Graph {
 						int64_t node_down = x + sxe * (y + 1);
 						adjacency[node_up] |= 0b0100;
 						adjacency[node_down] |= 0b1000;
+						any_edges = true;
 					}
 				}
 			}
@@ -113,6 +116,7 @@ struct Graph {
 						int64_t node_right = (x+1) + sxe * y;
 						adjacency[node_left] |= 0b0001;
 						adjacency[node_right] |= 0b0010;
+						any_edges = true;
 					}
 				}
 			}
@@ -126,6 +130,7 @@ struct Graph {
 						int64_t node_down = x + sxe * (y + 1);
 						adjacency[node_up] |= 0b0100;
 						adjacency[node_down] |= 0b1000;
+						any_edges = true;
 					}
 				}
 			}
@@ -138,10 +143,13 @@ struct Graph {
 						int64_t node_right = (x+1) + sxe * y;
 						adjacency[node_left] |= 0b0001;
 						adjacency[node_right] |= 0b0010;
+						any_edges = true;
 					}
 				}
 			}			
 		}
+
+		return any_edges;
 	}
 };
 
@@ -372,9 +380,14 @@ create_crack_codes(
 	bool permissible
 ) {
 	Graph G;
-	G.init(labels, sx, sy, permissible);
+	bool any_edges = G.init(labels, sx, sy, permissible);
 
 	std::vector<std::pair<int64_t, std::vector<char>>> chains;
+
+	if (!any_edges) {
+		return symbols_to_codepoints(chains);
+	}
+
 	std::vector<int64_t> revisit;
 	revisit.reserve(sx);
 	std::vector<uint8_t> revisit_ct((sx+1)*(sy+1));

--- a/src/crackcodes.hpp
+++ b/src/crackcodes.hpp
@@ -164,26 +164,20 @@ symbols_to_codepoints(
 	const uint64_t TERM[2] = { DirectionCode::DOWN, DirectionCode::UP };
 	const uint64_t TERM2[2] = { DirectionCode::RIGHT, DirectionCode::LEFT };
 
+	uint8_t lookup[256];
+	lookup[static_cast<uint8_t>('u')] = DirectionCode::UP;
+	lookup[static_cast<uint8_t>('d')] = DirectionCode::DOWN;
+	lookup[static_cast<uint8_t>('l')] = DirectionCode::LEFT;
+	lookup[static_cast<uint8_t>('r')] = DirectionCode::RIGHT;
+
 	for (auto [node, chain] : chains) {
 		std::vector<uint8_t> code;
-		code.reserve(chain.size());
+		code.reserve(chain.size() * 3 / 2); // account for b and t
 
 		for (uint64_t i = 0; i < chain.size(); i++) {
 			char symbol = chain[i];
 			if (symbol == 's') {
 				continue;
-			}
-			else if (symbol == 'u') {
-				code.push_back(DirectionCode::UP);
-			}
-			else if (symbol == 'd') {
-				code.push_back(DirectionCode::DOWN);
-			}
-			else if (symbol == 'l') {
-				code.push_back(DirectionCode::LEFT);
-			}
-			else if (symbol == 'r') {
-				code.push_back(DirectionCode::RIGHT);
 			}
 			else if (symbol == 'b') {
 				if (i > 0 && code.back() != BRANCH[1]) {
@@ -206,7 +200,7 @@ symbols_to_codepoints(
 				}
 			}
 			else {
-				throw std::runtime_error("Invalid symbol.");
+				code.push_back(lookup[static_cast<uint8_t>(symbol)]);
 			}
 		}
 		encoded_chains[node] = std::move(code);


### PR DESCRIPTION
Adds another 20%ish performance improvement for encoding.

I found the encoder does not need to compute the disjoint set or collect edges. Instead, we can scan through the adjacency graph looking for clusters, which is a memory aligned scan.

I also replaced 4 if statements in the symbol to codepoint encoder with a lookup table to reduce branch prediction errors.