### PR TITLE
feat: reencode files with different markov model orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 crackle data.npy # creates data.ckl
 crackle -m 5 data.npy # use a 5th order context model
 crackle -d data.ckl # recovers data.npy
+crackle -m 0 data.ckl # change markov model order
 ```
 
 ```python

--- a/crackle/codec.py
+++ b/crackle/codec.py
@@ -595,3 +595,7 @@ def condense_unique(binary:bytes) -> bytes:
     labels_binary,
     comps["crack_codes"],
   ])
+
+def reencode(binary:bytes, markov_model_order:int):
+  return fastcrackle.reencode_markov(binary, markov_model_order)
+

--- a/crackle/codec.py
+++ b/crackle/codec.py
@@ -597,5 +597,8 @@ def condense_unique(binary:bytes) -> bytes:
   ])
 
 def reencode(binary:bytes, markov_model_order:int):
+  head = header(binary)
+  if head.markov_model_order == markov_model_order:
+    return binary
   return fastcrackle.reencode_markov(binary, markov_model_order)
 

--- a/crackle/operations.py
+++ b/crackle/operations.py
@@ -9,6 +9,7 @@ from .codec import (
   compress, decompress, labels, 
   header, raw_labels, decode_flat_labels,
   num_labels, crack_codes, components,
+  reencode
 )
 from .headers import CrackleHeader, CrackFormat, LabelFormat, FormatError
 from .lib import width2dtype, compute_byte_width, compute_dtype
@@ -180,10 +181,17 @@ def zstack(images:Sequence[Union[np.ndarray, bytes]]) -> bytes:
 
     if isinstance(binary, np.ndarray):
       binary = compress(binary)
+    else:
+      binary = reencode(binary, markov_model_order=0)
 
     head = header(binary)
     if first_head is None:
       first_head = head 
+
+    if first_head.fortran_order:
+      binary = crackle.asfortranarray(binary)
+    else:
+      binary = crackle.ascontiguousarray(binary)
 
     if first_head.sx != head.sx or first_head.sy != head.sy:
       raise ValueError(
@@ -192,14 +200,10 @@ def zstack(images:Sequence[Union[np.ndarray, bytes]]) -> bytes:
       )
     if head.label_format != LabelFormat.FLAT:
       raise ValueError("Only the FLAT label format is compatible (for now).")
-    if head.markov_model_order != 0:
-      raise ValueError("Markov chain encoding not currently supported.")
     if head.grid_size != first_head.grid_size:
       raise ValueError("Grid sizes must match.")
     if head.crack_format != first_head.crack_format:
       raise ValueError("All crack formats must match.")
-    if head.fortran_order != first_head.fortran_order:
-      raise ValueError("All binaries must be in either Fortran or C order.")
     if head.data_width != first_head.data_width:
       raise ValueError("All binaries must be the same data width.")
     if head.signed != first_head.signed:

--- a/crackle/operations.py
+++ b/crackle/operations.py
@@ -189,9 +189,9 @@ def zstack(images:Sequence[Union[np.ndarray, bytes]]) -> bytes:
       first_head = head 
 
     if first_head.fortran_order:
-      binary = crackle.asfortranarray(binary)
+      binary = asfortranarray(binary)
     else:
-      binary = crackle.ascontiguousarray(binary)
+      binary = ascontiguousarray(binary)
 
     if first_head.sx != head.sx or first_head.sy != head.sy:
       raise ValueError(

--- a/crackle/util.py
+++ b/crackle/util.py
@@ -116,7 +116,7 @@ def save(
   ):
     return save_numpy(binary, filelike)
 
-  else:
+  if isinstance(labels, np.ndarray):
     binary = compress(labels, **kwargs)
 
   if hasattr(filelike, 'write'):

--- a/crackle_cli/cli.py
+++ b/crackle_cli/cli.py
@@ -127,7 +127,7 @@ def compress_file(src, allow_pins, markov, gzip):
 		dest += ".gz"
 
 	if is_crackle:
-		data.binary = crackle.codec.reencode(data.binary, markov_model_order=markov)
+		data.binary = crackle.codec.reencode(data.binary, markov_model_order=int(markov))
 		data.save(dest)
 	else:
 		crackle.save(data, dest, allow_pins=allow_pins, markov_model_order=int(markov))

--- a/crackle_cli/cli.py
+++ b/crackle_cli/cli.py
@@ -135,7 +135,7 @@ def compress_file(src, allow_pins, markov, gzip):
 
 	try:
 		stat = os.stat(dest)
-		if stat.st_size > 0:
+		if stat.st_size > 0 and dest != orig_src:
 			os.remove(orig_src)
 		else:
 			raise ValueError("File is zero length.")

--- a/crackle_cli/cli.py
+++ b/crackle_cli/cli.py
@@ -145,5 +145,5 @@ def compress_file(src, allow_pins, markov, gzip):
 
 def removesuffix(x:str, suffix:str) -> str:
   if x.endswith(suffix):
-    x = x[:-4]
+    x = x[:-len(suffix)]
   return x

--- a/crackle_cli/cli.py
+++ b/crackle_cli/cli.py
@@ -133,9 +133,12 @@ def compress_file(src, allow_pins, markov, gzip):
 		crackle.save(data, dest, allow_pins=allow_pins, markov_model_order=int(markov))
 	del data
 
+	if dest == orig_src:
+		return
+		
 	try:
 		stat = os.stat(dest)
-		if stat.st_size > 0 and dest != orig_src:
+		if stat.st_size > 0:
 			os.remove(orig_src)
 		else:
 			raise ValueError("File is zero length.")

--- a/src/crackcodes.hpp
+++ b/src/crackcodes.hpp
@@ -165,7 +165,7 @@ struct Graph {
 
 robin_hood::unordered_node_map<uint64_t, std::vector<uint8_t>>
 symbols_to_codepoints(
-	std::vector<std::pair<int64_t, std::vector<char>>> &chains
+	std::vector<std::pair<uint64_t, std::vector<unsigned char>>> &chains
 ) {
 	robin_hood::unordered_node_map<uint64_t, std::vector<uint8_t>> encoded_chains;
 
@@ -222,7 +222,7 @@ symbols_to_codepoints(
 
 int64_t remove_initial_branch(
 	int64_t node,
-	std::vector<char>& code,
+	std::vector<unsigned char>& code,
 	const int64_t sx, const int64_t sy
 ) {
 	if (code.empty()) {
@@ -387,7 +387,7 @@ create_crack_codes(
 	Graph G;
 	bool any_edges = G.init(labels, sx, sy, permissible);
 
-	std::vector<std::pair<int64_t, std::vector<char>>> chains;
+	std::vector<std::pair<uint64_t, std::vector<unsigned char>>> chains;
 
 	if (!any_edges) {
 		return symbols_to_codepoints(chains);
@@ -405,7 +405,7 @@ create_crack_codes(
 	while ((start_node = G.next_cluster(start_node)) != -1) {
 		int64_t node = start_node;
 
-		std::vector<char> code;
+		std::vector<unsigned char> code;
 		code.reserve(sx >> 2);
 		robin_hood::unordered_node_map<int64_t, std::vector<int64_t>> branch_nodes;
 		int64_t branches_taken = 1;
@@ -473,7 +473,7 @@ create_crack_codes(
 			start_node, code, sx, sy
 		);
 		chains.push_back(
-			std::make_pair(adjusted_start_node, code)
+			std::make_pair(static_cast<uint64_t>(adjusted_start_node), code)
 		);
 	}
 

--- a/src/crackle.hpp
+++ b/src/crackle.hpp
@@ -276,13 +276,12 @@ std::vector<std::vector<uint8_t>> decode_markov_model(
 	return crackle::markov::from_stored_model(stored_model, header.markov_model_order);
 }
 
-// vcg: voxel connectivity graph
-void crack_code_to_vcg(
+std::vector<std::pair<uint64_t, std::vector<unsigned char>> >
+crack_code_to_symbols(
   const std::vector<unsigned char>& code,
   const uint64_t sx, const uint64_t sy,
   const bool permissible, 
-  const std::vector<std::vector<uint8_t>>& markov_model,
-  uint8_t* slice_edges
+  const std::vector<std::vector<uint8_t>>& markov_model
 ) {
 	std::vector<uint64_t> nodes = crackle::crackcodes::read_boc_index(code, sx, sy);
 
@@ -296,7 +295,18 @@ void crack_code_to_vcg(
 		codepoints = crackle::markov::decode_codepoints(markov_stream, markov_model);
 	}
 
-	auto symbol_stream = crackle::crackcodes::codepoints_to_symbols(nodes, codepoints);
+	return crackle::crackcodes::codepoints_to_symbols(nodes, codepoints);
+}
+
+// vcg: voxel connectivity graph
+void crack_code_to_vcg(
+  const std::vector<unsigned char>& code,
+  const uint64_t sx, const uint64_t sy,
+  const bool permissible, 
+  const std::vector<std::vector<uint8_t>>& markov_model,
+  uint8_t* slice_edges
+) {
+	auto symbol_stream = crack_code_to_symbols(code, sx, sy, permissible, markov_model);
 	crackle::crackcodes::decode_crack_code(
 		symbol_stream, sx, sy, permissible, slice_edges
 	);
@@ -552,6 +562,101 @@ void decompress(
 		);
 	}
 }
+
+// take an existing crackle stream and change the markov order
+// returning a reencoded copy
+std::vector<unsigned char> reencode_with_markov_order(
+	const unsigned char* buffer, 
+	const size_t num_bytes,
+	const int markov_model_order
+) { 
+	if (num_bytes < CrackleHeader::header_size) {
+		std::string err = "crackle: Input too small to be a valid stream. Bytes: ";
+		err += std::to_string(num_bytes);
+		throw std::runtime_error(err);
+	}
+
+	CrackleHeader header(buffer);
+
+	if (header.format_version > 0) {
+		std::string err = "crackle: Invalid format version.";
+		err += std::to_string(header.format_version);
+		throw std::runtime_error(err);
+	}
+
+	std::vector<unsigned char> binary(buffer, buffer + num_bytes);
+
+	if (header.markov_model_order == markov_model_order) {
+		return binary;
+	}
+
+	// only used for markov compressed streams
+	std::vector<std::vector<uint8_t>> markov_model = decode_markov_model(header, binary);
+	
+	auto existing_crack_codes = get_crack_codes(header, binary, 0, header.sz);
+	const bool permissible = (header.crack_format == CrackFormat::PERMISSIBLE);
+
+	std::vector<robin_hood::unordered_node_map<uint64_t, std::vector<uint8_t>>> crack_codepoints;
+	for (auto& crack_code : existing_crack_codes) {
+		auto symbol_stream = crack_code_to_symbols(crack_code, header.sx, header.sy, permissible, markov_model);
+		auto unpacked_codepoints = crackle::crackcodes::symbols_to_codepoints(symbol_stream);
+		crack_codepoints.push_back(unpacked_codepoints);
+	}
+
+	header.markov_model_order = markov_model_order;
+
+	std::vector<unsigned char> stored_model; // only needed for markov
+	std::vector<std::vector<unsigned char>> crack_codes(crack_codepoints.size());
+	if (header.markov_model_order > 0) {
+		auto stats = crackle::markov::gather_statistics(crack_codepoints, header.markov_model_order);
+		auto model = crackle::markov::stats_to_model(stats);
+		stored_model = crackle::markov::to_stored_model(model);
+
+		for (uint64_t z = 0; z < crack_codepoints.size(); z++) {
+			crack_codes[z] = crackle::markov::compress(
+				crack_codepoints[z], model, header.markov_model_order,
+				header.sx, header.sy
+			);
+		}
+	}
+	else {
+		for (uint64_t z = 0; z < crack_codepoints.size(); z++) {
+			crack_codes[z] = crackle::crackcodes::pack_codepoints(crack_codepoints[z], header.sx, header.sy);
+		}
+	}
+
+	std::vector<unsigned char> z_index_binary(sizeof(uint32_t) * header.sz);
+	for (int64_t i = 0, z = 0; z < header.sz; z++) {
+		i += crackle::lib::itoc(static_cast<uint32_t>(crack_codes[z].size()), z_index_binary, i);
+	}
+
+	std::vector<unsigned char> labels_binary = crackle::labels::raw_labels(binary);
+
+	std::vector<unsigned char> final_binary = header.tobytes();
+	final_binary.insert(final_binary.end(), z_index_binary.begin(), z_index_binary.end());
+	final_binary.insert(final_binary.end(), labels_binary.begin(), labels_binary.end());
+	if (header.markov_model_order > 0) {
+		printf("here %d %d\n", header.markov_model_order, stored_model.size());
+		final_binary.insert(final_binary.end(), stored_model.begin(), stored_model.end());
+	}
+	for (auto& code : crack_codes) {
+		final_binary.insert(final_binary.end(), code.begin(), code.end());
+	}
+
+	return final_binary;
+}
+
+auto reencode_with_markov_order(
+	const std::string &buffer,
+	const int markov_model_order
+) {
+	return reencode_with_markov_order(
+		reinterpret_cast<const unsigned char*>(buffer.c_str()),
+		buffer.size(),
+		markov_model_order
+	);
+}
+
 
 };
 

--- a/src/crackle.hpp
+++ b/src/crackle.hpp
@@ -636,7 +636,6 @@ std::vector<unsigned char> reencode_with_markov_order(
 	final_binary.insert(final_binary.end(), z_index_binary.begin(), z_index_binary.end());
 	final_binary.insert(final_binary.end(), labels_binary.begin(), labels_binary.end());
 	if (header.markov_model_order > 0) {
-		printf("here %d %d\n", header.markov_model_order, stored_model.size());
 		final_binary.insert(final_binary.end(), stored_model.begin(), stored_model.end());
 	}
 	for (auto& code : crack_codes) {

--- a/src/fastcrackle.cpp
+++ b/src/fastcrackle.cpp
@@ -143,6 +143,13 @@ py::bytes compress(
 	}
 }
 
+py::bytes reencode_markov(
+	const py::bytes &buffer, const int markov_model_order
+) {
+	auto buf = crackle::reencode_with_markov_order(buffer, markov_model_order);
+	return py::bytes(reinterpret_cast<char*>(buf.data()), buf.size());
+}
+
 py::tuple connected_components(const py::array &labels) {
 	int width = labels.dtype().itemsize();
 
@@ -233,6 +240,7 @@ PYBIND11_MODULE(fastcrackle, m) {
 	m.doc() = "Accelerated crackle functions."; 
 	m.def("decompress", &decompress, "Decompress a crackle file into a numpy array.");
 	m.def("compress", &compress, "Compress a numpy array into a binary crackle file returned as bytes.");
+	m.def("reencode_markov", &reencode_markov, "Change the markov order of an existing crackle binary.");
 	m.def(
 		"connected_components", 
 		&connected_components,


### PR DESCRIPTION
This allows you to add, change, or strip markov context models from existing crackle files. One reason to do this: so you can merge them without decompressing.

Also fixes some bugs in the command line tool.