### PR TITLE
perf: lower encoding memory for flat labels 

### DIFF
--- a/src/cc3d.hpp
+++ b/src/cc3d.hpp
@@ -144,7 +144,7 @@ OUT* relabel(
   return out_labels;
 }
 
-uint64_t estimate_provisional_label_count(
+uint64_t estimate_provisional_label_count_vcg(
   const std::vector<uint8_t>& vcg, const int64_t sx
 ) {
   uint64_t count = 0; // number of transitions between labels
@@ -171,7 +171,7 @@ OUT* color_connectivity_graph(
   const int64_t sxy = sx * sy;
   const int64_t voxels = sx * sy * sz;
 
-  uint64_t max_labels = estimate_provisional_label_count(vcg, sx) + 1;
+  uint64_t max_labels = estimate_provisional_label_count_vcg(vcg, sx) + 1;
   max_labels = std::min(max_labels, static_cast<uint64_t>(std::numeric_limits<OUT>::max()));
 
   if (out_labels == NULL) {
@@ -222,6 +222,22 @@ OUT* color_connectivity_graph(
   return out_labels;
 }
 
+template <typename LABEL>
+uint64_t estimate_provisional_label_count(
+  const LABEL* in_labels, const int64_t sx, const int64_t voxels
+) {
+  uint64_t count = 0; // number of transitions between labels
+
+  for (int64_t loc = 0; loc < voxels; loc += sx) {
+    count += 1;
+    for (int64_t x = 1; x < sx; x++) {
+      count += (in_labels[loc + x] != in_labels[loc + x - 1]);
+    }
+  }
+
+  return count;
+}
+
 template <typename LABEL, typename OUT>
 OUT* connected_components2d_4(
     const LABEL* in_labels, 
@@ -233,7 +249,7 @@ OUT* connected_components2d_4(
   const int64_t sxy = sx * sy;
   const int64_t voxels = sx * sy * sz;
 
-  uint64_t max_labels = static_cast<uint64_t>(voxels) + 1; // + 1L for an array with no zeros
+  uint64_t max_labels = estimate_provisional_label_count<LABEL>(in_labels, sx, voxels) + 1;
   max_labels = std::min(max_labels, static_cast<uint64_t>(std::numeric_limits<OUT>::max()));
 
   DisjointSet<OUT> equivalences(max_labels);


### PR DESCRIPTION
reduces memory allocations by going slice by slice and uses provisional label estimation to shrink disjointset.