### PR TITLE
perf: much faster pins encoder

### DIFF
--- a/crackle/codec.py
+++ b/crackle/codec.py
@@ -543,7 +543,7 @@ def compress(
   labels = np.asfortranarray(labels)
   optimize_pins = (allow_pins == 2)
   return fastcrackle.compress(
-    labels, allow_pins, f_order,
+    labels, bool(allow_pins), f_order,
     markov_model_order, optimize_pins
   )
 

--- a/src/crackle.hpp
+++ b/src/crackle.hpp
@@ -33,7 +33,8 @@ std::vector<unsigned char> compress_helper(
 	const int64_t sx, const int64_t sy, const int64_t sz,
 	const bool allow_pins = false,
 	const bool fortran_order = true,
-	const uint64_t markov_model_order = 0
+	const uint64_t markov_model_order = 0,
+	const bool optimize_pins = false
 ) {
 	const int64_t voxels = sx * sy * sz;
 
@@ -124,7 +125,7 @@ std::vector<unsigned char> compress_helper(
 	
 	std::vector<unsigned char> labels_binary;
 	if (label_format == LabelFormat::PINS_VARIABLE_WIDTH) {
-		auto [all_pins, num_components_per_slice, num_components] = crackle::pins::compute(labels, sx, sy, sz);
+		auto [all_pins, num_components_per_slice, num_components] = crackle::pins::compute(labels, sx, sy, sz, optimize_pins);
 		labels_binary = crackle::labels::encode_condensed_pins<LABEL, STORED_LABEL>(
 			all_pins,
 			sx, sy, sz,
@@ -133,7 +134,7 @@ std::vector<unsigned char> compress_helper(
 		);
 	}
 	// else if (label_format == LabelFormat::PINS_FIXED_WIDTH) {
-	// 	auto [all_pins, num_components_per_slice, num_components] = crackle::pins::compute(labels, sx, sy, sz);
+	// 	auto [all_pins, num_components_per_slice, num_components] = crackle::pins::compute(labels, sx, sy, sz, optimize_pins);
 	// 	labels_binary = crackle::labels::encode_fixed_width_pins<LABEL, STORED_LABEL>(
 	// 		all_pins,
 	// 		sx, sy, sz,
@@ -172,7 +173,8 @@ std::vector<unsigned char> compress(
 	const int64_t sx, const int64_t sy, const int64_t sz,
 	const bool allow_pins = false,
 	const bool fortran_order = true,
-	const uint64_t markov_model_order = 0
+	const uint64_t markov_model_order = 0,
+	const bool optimize_pins = false
 ) {
 	const int64_t voxels = sx * sy * sz;
 	uint8_t stored_data_width = crackle::lib::compute_byte_width(
@@ -180,16 +182,28 @@ std::vector<unsigned char> compress(
 	);
 
 	if (stored_data_width == 1) {
-		return compress_helper<LABEL, uint8_t>(labels, sx, sy, sz, allow_pins, fortran_order, markov_model_order);
+		return compress_helper<LABEL, uint8_t>(
+			labels, sx, sy, sz, 
+			allow_pins, fortran_order, markov_model_order, optimize_pins
+		);
 	}
 	else if (stored_data_width == 2) {
-		return compress_helper<LABEL, uint16_t>(labels, sx, sy, sz, allow_pins, fortran_order, markov_model_order);
+		return compress_helper<LABEL, uint16_t>(
+			labels, sx, sy, sz, 
+			allow_pins, fortran_order, markov_model_order, optimize_pins
+		);
 	}
 	else if (stored_data_width == 4) {
-		return compress_helper<LABEL, uint32_t>(labels, sx, sy, sz, allow_pins, fortran_order, markov_model_order);
+		return compress_helper<LABEL, uint32_t>(
+			labels, sx, sy, sz,
+			allow_pins, fortran_order, markov_model_order, optimize_pins
+		);
 	}
 	else {
-		return compress_helper<LABEL, uint64_t>(labels, sx, sy, sz, allow_pins, fortran_order, markov_model_order);
+		return compress_helper<LABEL, uint64_t>(
+			labels, sx, sy, sz,
+			allow_pins, fortran_order,markov_model_order, optimize_pins
+		);
 	}
 }
 

--- a/src/fastcrackle.cpp
+++ b/src/fastcrackle.cpp
@@ -85,7 +85,8 @@ py::bytes compress_helper(
 	const py::array &labels, 
 	const bool allow_pins = false,
 	const bool fortran_order = true,
-	const uint64_t markov_model_order = 0
+	const uint64_t markov_model_order = 0,
+	const bool optimize_pins = false
 ) {
 	const uint64_t sx = labels.shape()[0];
 	const uint64_t sy = labels.ndim() < 2
@@ -100,7 +101,8 @@ py::bytes compress_helper(
 		sx, sy, sz,
 		allow_pins,
 		fortran_order,
-		markov_model_order
+		markov_model_order,
+		optimize_pins
 	);
 	return py::bytes(reinterpret_cast<char*>(buf.data()), buf.size());
 }
@@ -109,7 +111,8 @@ py::bytes compress(
 	const py::array &labels, 
 	const bool allow_pins = false,
 	const bool fortran_order = true,
-	const uint64_t markov_model_order = 0
+	const uint64_t markov_model_order = 0,
+	const bool optimize_pins = false
 ) {
 	int width = labels.dtype().itemsize();
 	bool is_signed = labels.dtype().kind() == 'i';
@@ -117,44 +120,44 @@ py::bytes compress(
 	if (is_signed) {
 		if (width == 1) {
 			return compress_helper<int8_t>(
-				labels, allow_pins, fortran_order, markov_model_order
+				labels, allow_pins, fortran_order, markov_model_order, optimize_pins
 			);
 		}
 		else if (width == 2) {
 			return compress_helper<int16_t>(
-				labels, allow_pins, fortran_order, markov_model_order
+				labels, allow_pins, fortran_order, markov_model_order, optimize_pins
 			);
 		}
 		else if (width == 4) {
 			return compress_helper<int32_t>(
-				labels, allow_pins, fortran_order, markov_model_order
+				labels, allow_pins, fortran_order, markov_model_order, optimize_pins
 			);
 		}
 		else {
 			return compress_helper<int64_t>(
-				labels, allow_pins, fortran_order, markov_model_order
+				labels, allow_pins, fortran_order, markov_model_order, optimize_pins
 			);
 		}
 	}
 	else {
 		if (width == 1) {
 			return compress_helper<uint8_t>(
-				labels, allow_pins, fortran_order, markov_model_order
+				labels, allow_pins, fortran_order, markov_model_order, optimize_pins
 			);
 		}
 		else if (width == 2) {
 			return compress_helper<uint16_t>(
-				labels, allow_pins, fortran_order, markov_model_order
+				labels, allow_pins, fortran_order, markov_model_order, optimize_pins
 			);
 		}
 		else if (width == 4) {
 			return compress_helper<uint32_t>(
-				labels, allow_pins, fortran_order, markov_model_order
+				labels, allow_pins, fortran_order, markov_model_order, optimize_pins
 			);
 		}
 		else {
 			return compress_helper<uint64_t>(
-				labels, allow_pins, fortran_order, markov_model_order
+				labels, allow_pins, fortran_order, markov_model_order, optimize_pins
 			);
 		}
 	}
@@ -237,25 +240,25 @@ auto compute_pins(const py::array &labels) {
 	if (width == 1) {
 		return crackle::pins::compute<uint8_t>(
 			reinterpret_cast<uint8_t*>(const_cast<void*>(labels.data())),
-			sx, sy, sz
+			sx, sy, sz, false
 		);
 	}
 	else if (width == 2) {
 		return crackle::pins::compute<uint16_t>(
 			reinterpret_cast<uint16_t*>(const_cast<void*>(labels.data())),
-			sx, sy, sz
+			sx, sy, sz, false
 		);
 	}
 	else if (width == 4) {
 		return crackle::pins::compute<uint32_t>(
 			reinterpret_cast<uint32_t*>(const_cast<void*>(labels.data())),
-			sx, sy, sz
+			sx, sy, sz, false
 		);
 	}
 	else {
 		return crackle::pins::compute<uint64_t>(
 			reinterpret_cast<uint64_t*>(const_cast<void*>(labels.data())),
-			sx, sy, sz
+			sx, sy, sz, false
 		);
 	}
 }

--- a/src/pins.hpp
+++ b/src/pins.hpp
@@ -351,7 +351,8 @@ std::tuple<
 >
 compute(
 	const LABEL* labels,
-	const uint64_t sx, const uint64_t sy, const uint64_t sz
+	const uint64_t sx, const uint64_t sy, const uint64_t sz,
+	const bool optimize
 ) {
 	std::vector<uint64_t> num_components_per_slice(sz);
 	uint64_t N_total = 0;
@@ -372,8 +373,10 @@ compute(
 		labels, cc_labels.get(), sx, sy, sz, N_total
 	);
 
+	auto find_pins_fn = optimize ? find_optimal_pins : find_suboptimal_pins;
+
 	for (auto [label, pins] : pinsets) {
-		all_pins[label] = find_suboptimal_pins(
+		all_pins[label] = find_pins_fn(
 			pins, multiverse[label], cc_labels, 
 			sx, sy, sz
 		);

--- a/src/pins.hpp
+++ b/src/pins.hpp
@@ -311,6 +311,7 @@ std::vector<CandidatePin> find_suboptimal_pins(
 	final_pins.reserve(pinsets.size() / 10);
 
 	robin_hood::unordered_node_map<int64_t, std::vector<int64_t>> component_to_pins;
+	component_to_pins.reserve(universe.size());
 
 	for (uint64_t i = 0; i < pinsets.size(); i++) {
 		CandidatePin& pin = pinsets[i];

--- a/src/pins.hpp
+++ b/src/pins.hpp
@@ -230,11 +230,12 @@ std::vector<CandidatePin> find_optimal_pins(
 	const uint64_t sx, const uint64_t sy, const uint64_t sz
 ) {	
 	std::vector<CandidatePin> final_pins;
-	final_pins.reserve(final_pins.size() / 10);
 
 	if (pinsets.size() == 0) {
 		return final_pins;
 	}
+
+	final_pins.reserve(pinsets.size() / 10);
 
 	crackle::pairing_heap::MinHeap<int64_t, int64_t> heap;
 


### PR DESCRIPTION
I added a new algorithm (find_suboptimal_pins) that picks the largest pin from the remaining ccs rather than trying to find the biggest remaining pin (slow, many hash accesses). This vastly reduced the time. connectomics.npy now runs in about 9 seconds (previously 1327 seconds). Pin use is now practical for many applications.

I wrote a small script to compare different combinations of features on connectomics.npy.

```
flat labels/flat cracks: 4610.2kB
flat labels/flat cracks+gz: 3125.8kB
pins/flat cracks: 3945.1kB
pins/flat cracks+gz: 2997.1kB
flat/markov: 3802.9kB
flat/markov+gz: 2880.3kB
pins/markov: 3137.7kB
pins/markov+gz: 2751.8kB
```

It seems that markov + suboptimal pins save space even gzipped. It is reduced 12% compared with flat/flat. 

pins + markov is reduced 32% from flat/flat in the no gzip condition while still being usable.

You can still use the older algorithm by specifying `allow_pins=2`.

Pin encoding could be made even faster. The dominant time use in profiling comes from `extract_columns` mostly from `add_pin`. This hash access could be avoided if we renumber the input labels somehow.
