### PR TITLE
feat: set manual bgcolor

### DIFF
--- a/crackle/codec.py
+++ b/crackle/codec.py
@@ -464,7 +464,8 @@ def decompress_range(binary:bytes, z_start:Optional[int], z_end:Optional[int]) -
 def compress(
   labels:np.ndarray, 
   allow_pins:int = 0,
-  markov_model_order:int = 0
+  markov_model_order:int = 0,
+  bgcolor:Optional[int] = None,
 ) -> bytes:
   """
   Compress the 3D labels array into a Crackle bytestream.
@@ -477,9 +478,7 @@ def compress(
     Reasonable values range from 0 (no model (0B), 
     larger crack code size, fast decode) to about 10 (655kB). 
     Values of 5 (model:640B) to 7 (model:10kB) are typical.
-
-  [EXPERIMENTAL]
-  BINARIES ENCODED USING THIS OPTION MAY BREAK IN FUTURE VERSIONS
+  
   allow_pins: 
     0: disabled
     1: use fast pin algorithm
@@ -488,9 +487,11 @@ def compress(
     If enabled (1 or 2), when the number of voxel pairs in the 
     volume is > 50% of the number of voxels, use the pin encoding
     strategy. Pins use 3D information to encode the label map.
-    However, they are still investigational.
+    
     Pin computation requires appoximately solving a set cover problem and 
     can be very slow on larger images using the slow algorithm.
+
+    
   """
   if np.issubdtype(labels.dtype, np.signedinteger):
     raise TypeError("Signed integer data types are not currently supported.")
@@ -498,9 +499,13 @@ def compress(
   f_order = labels.flags.f_contiguous
   labels = np.asfortranarray(labels)
   optimize_pins = (allow_pins == 2)
+  auto_bgcolor = (bgcolor is None)
+  manual_bgcolor = 0 if bgcolor is None else int(bgcolor)
+
   return fastcrackle.compress(
     labels, bool(allow_pins), f_order,
-    markov_model_order, optimize_pins
+    markov_model_order, optimize_pins,
+    auto_bgcolor, manual_bgcolor
   )
 
 def extract_keys(binary:bytes) -> np.ndarray:

--- a/src/crackle.hpp
+++ b/src/crackle.hpp
@@ -34,7 +34,9 @@ std::vector<unsigned char> compress_helper(
 	const bool allow_pins = false,
 	const bool fortran_order = true,
 	const uint64_t markov_model_order = 0,
-	const bool optimize_pins = false
+	const bool optimize_pins = false,
+	const bool auto_bgcolor = true,
+	const bool manual_bgcolor = 0
 ) {
 	const int64_t voxels = sx * sy * sz;
 
@@ -130,7 +132,8 @@ std::vector<unsigned char> compress_helper(
 			all_pins,
 			sx, sy, sz,
 			header.pin_index_width(),
-			num_components_per_slice, num_components
+			num_components_per_slice, num_components,
+			auto_bgcolor, manual_bgcolor
 		);
 	}
 	else {
@@ -166,37 +169,35 @@ std::vector<unsigned char> compress(
 	const bool allow_pins = false,
 	const bool fortran_order = true,
 	const uint64_t markov_model_order = 0,
-	const bool optimize_pins = false
+	const bool optimize_pins = false,
+	const bool auto_bgcolor = true,
+	const int64_t manual_bgcolor = 0
 ) {
 	const int64_t voxels = sx * sy * sz;
 	uint8_t stored_data_width = crackle::lib::compute_byte_width(
 		crackle::lib::max_label(labels, voxels)
 	);
 
+#define CALL_COMPRESS_HELPER(STORED_T) compress_helper<LABEL, STORED_T>(\
+		labels, sx, sy, sz,\
+		allow_pins, fortran_order, markov_model_order,\
+		optimize_pins, auto_bgcolor, manual_bgcolor\
+	)
+
 	if (stored_data_width == 1) {
-		return compress_helper<LABEL, uint8_t>(
-			labels, sx, sy, sz, 
-			allow_pins, fortran_order, markov_model_order, optimize_pins
-		);
+		return CALL_COMPRESS_HELPER(uint8_t);
 	}
 	else if (stored_data_width == 2) {
-		return compress_helper<LABEL, uint16_t>(
-			labels, sx, sy, sz, 
-			allow_pins, fortran_order, markov_model_order, optimize_pins
-		);
+		return CALL_COMPRESS_HELPER(uint16_t);
 	}
 	else if (stored_data_width == 4) {
-		return compress_helper<LABEL, uint32_t>(
-			labels, sx, sy, sz,
-			allow_pins, fortran_order, markov_model_order, optimize_pins
-		);
+		return CALL_COMPRESS_HELPER(uint32_t);
 	}
 	else {
-		return compress_helper<LABEL, uint64_t>(
-			labels, sx, sy, sz,
-			allow_pins, fortran_order,markov_model_order, optimize_pins
-		);
+		return CALL_COMPRESS_HELPER(uint64_t);
 	}
+
+#undef CALL_COMPRESS_HELPER
 }
 
 

--- a/src/labels.hpp
+++ b/src/labels.hpp
@@ -154,9 +154,15 @@ std::vector<unsigned char> encode_condensed_pins(
 	const int64_t sx, const int64_t sy, const int64_t sz,
 	const int64_t index_width, 
 	const std::vector<uint64_t>& num_components_per_slice,
-	const uint64_t num_components
+	const uint64_t num_components,
+	const bool auto_bgcolor = true,
+	const STORED_LABEL manual_bgcolor = 0
 ) {
-	STORED_LABEL bgcolor = find_bgcolor<STORED_LABEL>(all_pins, sz);
+	STORED_LABEL bgcolor = manual_bgcolor;
+	if (auto_bgcolor) {
+		bgcolor = find_bgcolor<STORED_LABEL>(all_pins, sz);
+	}
+
 	all_pins.erase(bgcolor);
 
 	uint64_t max_pins = 0;


### PR DESCRIPTION
For merging pin encoded binaries, the bgcolor must match. Manually setting it to e.g. 0 will ensure your binaries can be stacked, though the compressed size may be suboptimal.