### PR TITLE
feat: Format Version 1 (extended labels, crc16 protects header)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,14 +103,14 @@ See benchmarks for more information on Crackle's size and compute effiency.
 | Format Version | Description                                                    |
 |---------------|----------------|----------------------------------------------------------------|
 | 0              | Initial release w/ flat, pins, crack codes with finite context modeling. Beta. |
-| 1              | Incr. header to 30 bytes from 24. num_label_bytes u32->u64, adds crc16 to protect header. |
+| 1              | Incr. header to 30 bytes from 24. num_label_bytes u32->u64, adds crc8 to protect header. |
 
 
 ## Stream Format
 
 | Section   | Bytes                                     | Description                                                                                                     |
 |-----------|-------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
-| Header    | v0: 24, v1: 30                            | Metadata incl. length of fields.                                                                                |
+| Header    | v0: 24, v1: 29                            | Metadata incl. length of fields.                                                                                |
 | Crack Index     | header.sz * sizeof(uint32)             | Number of bytes for the crack codes in each slice.
 | Labels       | header.num_label_bytes        | Can be either "flat" labels or "pins". Describes how to color connected components.                                                                                   |
 | Crack Codes    | Variable length.           | Instructions for drawing crack boundaries.             |
@@ -126,7 +126,7 @@ See benchmarks for more information on Crackle's size and compute effiency.
 | sx, sy, sz        | >= 0              | u32 x 3 | Size of array dimensions.                       |
 | grid_size         | log2(grid_size)   | u8      | Stores log2 of grid dimensions in voxels.          |
 | num_label_bytes   | Any.              | u64      | Number of bytes of the labels section. Note the labels come in at least two format types.          |
-| crc16             | Any.              | u16      | CRC16 of format_field thru num_label_bytes using polynomial 0xac9a (implicit) and 0xFFFF initialization. |
+| crc8             | Any.              | u8      | CRC8 of format_field thru num_label_bytes using polynomial 0xe7 (implicit) and 0xFF initialization. |
 
 
 Format Field (u16): DDSSCLLFGOOOOURR (each letter represents a bit, left is LSB)
@@ -141,7 +141,7 @@ OOOO: Nth-Order of Markov Chain (as an unsigned integer, typical values 0, or 3 
 U: if 0, unique labels are sorted, else, unsorted  
 R: Reserved  
 
-CRC16 only covers the header. It doesn't cover the magic number or format version since those are easily human correctable if needed.
+CRC8 only covers the header. It doesn't cover the magic number or format version since those are easily human correctable if needed.
 
 ### Flat Label Format
 

--- a/README.md
+++ b/README.md
@@ -100,16 +100,17 @@ See benchmarks for more information on Crackle's size and compute effiency.
 
 ## Versions
 
-| Major Version | Format Version | Description                                                    |
+| Format Version | Description                                                    |
 |---------------|----------------|----------------------------------------------------------------|
-| 1             | 0              | Initial release w/ flat, pins, crack codes with finite context modeling. Beta. |
+| 0              | Initial release w/ flat, pins, crack codes with finite context modeling. Beta. |
+| 1              | Incr. header to 30 bytes from 24. num_label_bytes u32->u64, adds crc16 to protect header. |
 
 
 ## Stream Format
 
 | Section   | Bytes                                     | Description                                                                                                     |
 |-----------|-------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
-| Header    | 24                                        | Metadata incl. length of fields.                                                                                |
+| Header    | v0: 24, v1: 30                            | Metadata incl. length of fields.                                                                                |
 | Crack Index     | header.sz * sizeof(uint32)             | Number of bytes for the crack codes in each slice.
 | Labels       | header.num_label_bytes        | Can be either "flat" labels or "pins". Describes how to color connected components.                                                                                   |
 | Crack Codes    | Variable length.           | Instructions for drawing crack boundaries.             |
@@ -124,7 +125,8 @@ See benchmarks for more information on Crackle's size and compute effiency.
 | format_field      | bitfield          | u16     | See below.                 |
 | sx, sy, sz        | >= 0              | u32 x 3 | Size of array dimensions.                       |
 | grid_size         | log2(grid_size)   | u8      | Stores log2 of grid dimensions in voxels.          |
-| num_label_bytes   | Any.              | u32      | Number of bytes of the labels section. Note the labels come in at least two format types.          |
+| num_label_bytes   | Any.              | u64      | Number of bytes of the labels section. Note the labels come in at least two format types.          |
+| crc16             | Any.              | u16      | CRC16 of format_field thru num_label_bytes using polynomial 0xac9a (implicit) and 0xFFFF initialization. |
 
 
 Format Field (u16): DDSSCLLFGOOOOURR (each letter represents a bit, left is LSB)
@@ -138,6 +140,8 @@ G: Signed (if (1), data are signed int, otherwise unsigned int)
 OOOO: Nth-Order of Markov Chain (as an unsigned integer, typical values 0, or 3 to 7). If 0, markov compression is disabled.  
 U: if 0, unique labels are sorted, else, unsorted  
 R: Reserved  
+
+CRC16 only covers the header. It doesn't cover the magic number or format version since those are easily human correctable if needed.
 
 ### Flat Label Format
 

--- a/automated_test.py
+++ b/automated_test.py
@@ -488,6 +488,53 @@ def test_min_max(allow_pins, dtype):
   assert ans_min == crackle.min(binary)
   assert ans_max == crackle.max(binary)
 
+@pytest.mark.parametrize("dtype", [np.uint8, np.uint16, np.uint32, np.uint64])
+def test_crc_check_one_bit_error(dtype):
+  arr = np.random.randint(0, 255, size=[11,23,37], dtype=dtype)
+  binary = bytearray(crackle.compress(arr))
+
+  head = crackle.header(binary) # crashes if bad
+  binary[0] = ord('z')
+
+  try:
+    head = crackle.header(binary) # crashes if bad
+    assert False
+  except:
+    pass
+
+  binary[0] = ord('c') # fixes
+  head = crackle.header(binary) # crashes if bad
+  binary[4] = 100
+  
+  try:
+    head = crackle.header(binary) # crashes if bad
+    assert False
+  except:
+    pass
+
+  binary[4] = 1
+  head = crackle.header(binary) # crashes if bad
+
+  # now to see if crc actually works....
+  # tests 28, 29 are false positives btw
+  for i in range(5, 30):
+    for j in range(8):
+      val = binary[i]
+      binary[i] |= (0b1 << j)
+
+      try:
+        head = crackle.header(binary) # crashes if bad
+        assert False, i
+      except:
+        pass
+
+      binary[i] = val
+
+
+
+
+
+
 
 
 

--- a/automated_test.py
+++ b/automated_test.py
@@ -530,6 +530,19 @@ def test_crc_check_one_bit_error(dtype):
 
       binary[i] = val
 
+  for i in range(5, 30):
+    for j in range(8):
+      val = binary[i]
+      binary[i] = binary[i] & ~(0b1 << j)
+
+      try:
+        head = crackle.header(binary) # crashes if bad
+        assert False, i
+      except:
+        pass
+
+      binary[i] = val
+
 
 
 

--- a/automated_test.py
+++ b/automated_test.py
@@ -515,6 +515,7 @@ def test_crc_check_one_bit_error(dtype):
   binary[4] = 1
   head = crackle.header(binary) # crashes if bad
 
+  # Hamming Distance 1
   # now to see if crc actually works....
   # tests 28, 29 are false positives btw
   for i in range(5, 30):
@@ -542,6 +543,47 @@ def test_crc_check_one_bit_error(dtype):
         pass
 
       binary[i] = val
+
+
+  # Hamming Distance 2
+  orig_binary = bytearray(binary)
+  N = 184
+
+  for i in range(N):
+    for j in range(i, N):
+      binary = bytearray(orig_binary)
+
+      ii = i // 8
+      jj = j // 8
+      iib = i - ii * 8
+      jjb = j - jj * 8
+
+      binary[ii] |= (0b1 << iib)
+      binary[jj] |= (0b1 << jjb)
+
+      try:
+        head = crackle.header(binary) # crashes if bad
+        assert False, i
+      except:
+        pass
+
+  for i in range(N):
+    for j in range(i, N):
+      binary = bytearray(orig_binary)
+
+      ii = i // 8
+      jj = j // 8
+      iib = i - ii * 8
+      jjb = j - jj * 8
+
+      binary[ii] = binary[ii] & ~(0b1 << iib)
+      binary[jj] = binary[jj] & ~(0b1 << jjb)
+
+      try:
+        head = crackle.header(binary) # crashes if bad
+        assert False, i
+      except:
+        pass
 
 
 

--- a/crackle/array.py
+++ b/crackle/array.py
@@ -30,8 +30,8 @@ class CrackleArray:
   def __len__(self):
     return len(self.binary)
 
-  def header(self):
-    return header(self.binary)
+  def header(self, ignore_crc_check:bool = False):
+    return header(self.binary, ignore_crc_check=ignore_crc_check)
 
   @property
   def random_access(self):

--- a/crackle/codec.py
+++ b/crackle/codec.py
@@ -18,7 +18,7 @@ def labels(binary:bytes) -> np.ndarray:
   if head.voxels() == 0:
     return np.zeros((0,), dtype=head.dtype)
 
-  hb = CrackleHeader.HEADER_BYTES
+  hb = head.header_bytes
   offset = hb + head.sz * 4
 
   if head.label_format == LabelFormat.FLAT:
@@ -46,7 +46,7 @@ def labels(binary:bytes) -> np.ndarray:
 def num_labels(binary:bytes) -> int:
   """Returns the number of unique labels."""
   head = header(binary)
-  hb = CrackleHeader.HEADER_BYTES
+  hb = head.header_bytes
 
   if head.voxels() == 0:
     return 0
@@ -66,7 +66,7 @@ def contains(binary:bytes, label:int) -> bool:
   if not head.is_sorted:
     return label in labels(binary)
 
-  hb = CrackleHeader.HEADER_BYTES
+  hb = head.header_bytes
   offset = hb + head.sz * 4
 
   # bgcolor, num labels (u64), N labels, pins
@@ -148,7 +148,7 @@ def background_color(binary:bytes) -> int:
   if header.label_format == LabelFormat.FLAT:
     raise FormatError("Background color can only be extracted from pin encoded streams.")
 
-  offset = CrackleHeader.HEADER_BYTES + header.sz * 4
+  offset = header.header_bytes + header.sz * 4
   dtype = width2dtype[header.stored_data_width]
   bgcolor = np.frombuffer(binary[offset:offset+header.stored_data_width], dtype=dtype)
   return int(bgcolor[0])
@@ -164,7 +164,7 @@ def decode_pins(binary:bytes) -> np.ndarray:
 def decode_condensed_pins_components(binary:bytes) -> dict:
   components = {}
   head = CrackleHeader.frombytes(binary)
-  hb = CrackleHeader.HEADER_BYTES
+  hb = head.header_bytes
 
   if head.label_format != LabelFormat.PINS_VARIABLE_WIDTH:
     raise FormatError("This function can only extract pins from variable width streams.")

--- a/crackle/codec.py
+++ b/crackle/codec.py
@@ -8,9 +8,9 @@ import fastcrackle
 from .headers import CrackleHeader, CrackFormat, LabelFormat, FormatError
 from .lib import width2dtype, compute_byte_width, compute_dtype
 
-def header(binary:bytes) -> CrackleHeader:
+def header(binary:bytes, ignore_crc_check:bool = False) -> CrackleHeader:
   """Decode the header from a Crackle bytestream."""
-  return CrackleHeader.frombytes(binary)
+  return CrackleHeader.frombytes(binary, ignore_crc_check=ignore_crc_check)
 
 def labels(binary:bytes) -> np.ndarray:
   """Extract the unique labels from a Crackle bytestream."""

--- a/crackle/headers.py
+++ b/crackle/headers.py
@@ -216,6 +216,9 @@ class CrackleHeader:
   def voxels(self) -> int:
     return self.sx * self.sy * self.sz
 
+  def compute_crc(self) -> int:
+    return int.from_bytes(self.tobytes()[-2:], 'little')
+
   @property
   def num_markov_model_bytes(self) -> int:
     if self.markov_model_order == 0:

--- a/crackle/headers.py
+++ b/crackle/headers.py
@@ -20,28 +20,6 @@ class CrackFormat(IntEnum):
   IMPERMISSIBLE = 0
   PERMISSIBLE = 1
 
-# Code from stackoverflow by Dr. Mark Adler
-# https://stackoverflow.com/questions/10564491/function-to-calculate-a-crc16-checksum#comment83704063_10569892
-# Polynomial 0xac9a is selected as "best" for messages up to
-# 241 bits and gives a guarantee of detecting up to 4 bit flips
-# according to Phil Koopman. By coincidence, this polynomial
-# is palindromic, so works for both little and big endian.
-# https://users.ece.cmu.edu/~koopman/crc/
-def crc16(data:List[int]) -> int:
-  # use implicit +1 representation for right shift, LSB first
-  # use explicit +1 representation for left shit, MSB first
-  polynomial = 0xac9a # implicit
-  crc = 0xFFFF # detects zeroed data better than 0x0000
-  for i in range(len(data)):
-    crc ^= data[i]
-    for k in range(8):
-      if crc & 1:
-        crc = (crc >> 1) ^ polynomial
-      else:
-        crc = crc >> 1
-
-  return int(crc & 0xFFFF)
-
 def crc8(data:List[int]) -> int:
   # use implicit +1 representation for right shift, LSB first
   # use explicit +1 representation for left shit, MSB first

--- a/crackle/headers.py
+++ b/crackle/headers.py
@@ -38,9 +38,8 @@ class CrackleHeader:
     signed:bool,
     markov_model_order:int,
     is_sorted:bool,
-    format_version:int,
+    format_version:int = 1,
   ):
-    self.format_version = format_version
     self.label_format = label_format
     self.crack_format = crack_format
     self.data_width = int(data_width)
@@ -54,6 +53,7 @@ class CrackleHeader:
     self.signed = bool(signed)
     self.markov_model_order = int(markov_model_order)
     self.is_sorted = bool(is_sorted)
+    self.format_version = format_version
 
   @classmethod
   def frombytes(kls, buffer:bytes):
@@ -118,16 +118,21 @@ class CrackleHeader:
 
     log_grid_size = int(np.log2(self.grid_size))
 
+    if self.format_version == 0:
+      label_bytes_width = 4
+    else:
+      label_bytes_width = 8
+
     return b''.join([
       self.MAGIC,
-      self.FORMAT_VERSION.to_bytes(1, 'little'),
+      self.format_version.to_bytes(1, 'little'),
       fmt_byte.to_bytes(1, 'little'),
       fmt_byte2.to_bytes(1, 'little'),
       self.sx.to_bytes(4, 'little'),
       self.sy.to_bytes(4, 'little'),
       self.sz.to_bytes(4, 'little'),
       log_grid_size.to_bytes(1, 'little'),
-      self.num_label_bytes.to_bytes(4, 'little'),
+      self.num_label_bytes.to_bytes(label_bytes_width, 'little'),
     ])
 
   def pin_index_width(self):
@@ -179,7 +184,7 @@ class CrackleHeader:
 
     return f"""
     magic:         {CrackleHeader.MAGIC}
-    version:       {CrackleHeader.FORMAT_VERSION}
+    version:       {self.format_version}
     label fmt:     {label_fmt}
     crack fmt:     {'PERMISSIBLE' if self.crack_format == CrackFormat.PERMISSIBLE else 'IMPERMISSIBLE' }
     data width:    {self.data_width}

--- a/crackle/operations.py
+++ b/crackle/operations.py
@@ -74,7 +74,7 @@ def remap(binary:bytes, mapping:dict, preserve_missing_labels:bool = False) -> b
   binary = bytearray(binary)
   
   head = CrackleHeader.frombytes(binary)
-  hb = CrackleHeader.HEADER_BYTES
+  hb = head.header_bytes
 
   # flat: num_labels, N labels, remapped labels
   # pins: bgcolor, num labels (u64), N labels, pins
@@ -122,7 +122,7 @@ def astype(binary:bytes, dtype) -> bytes:
   head.data_width = np.dtype(dtype).itemsize
   return b''.join([ 
     head.tobytes(), 
-    binary[CrackleHeader.HEADER_BYTES:] 
+    binary[head.header_bytes:] 
   ])
 
 def refit(binary:bytes) -> bytes:
@@ -150,7 +150,7 @@ def renumber(binary:bytes, start=0) -> Tuple[bytes, dict]:
     head.is_sorted = True
     binary = b''.join([
       head.tobytes(),
-      binary[CrackleHeader.HEADER_BYTES:]
+      binary[head.header_bytes:]
     ])
 
   return (binary, mapping)
@@ -527,7 +527,7 @@ def asfortranarray(binary:bytes) -> bytes:
 
   return b''.join([
     head.tobytes(),
-    binary[CrackleHeader.HEADER_BYTES:],
+    binary[head.header_bytes:],
   ])
 
 def ascontiguousarray(binary:bytes) -> bytes:
@@ -540,7 +540,7 @@ def ascontiguousarray(binary:bytes) -> bytes:
 
   return b''.join([
     head.tobytes(),
-    binary[CrackleHeader.HEADER_BYTES:],
+    binary[head.header_bytes:],
   ])
 
 def full(shape, fill_value, dtype=None, order='C') -> bytes:

--- a/crackle_cli/cli.py
+++ b/crackle_cli/cli.py
@@ -67,7 +67,7 @@ def print_header(src):
 		print(f"crackle: File \"{src}\" does not exist.")
 		return
 
-	head = arr.header()
+	head = arr.header(ignore_crc_check=True)
 	print(f"Filename: {src}")
 	for key,val in head.__dict__.items():
 		print(f"{key}: {val}")

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ setuptools.setup(
     Pybind11Extension(
         "fastcrackle",
         ["src/fastcrackle.cpp"],
+        include_dirs=["./third_party/crc32c/include"],
+        libraries=["crc32c"],
         extra_compile_args=extra_compile_args,
         language="c++",
     ),

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,6 @@ setuptools.setup(
     Pybind11Extension(
         "fastcrackle",
         ["src/fastcrackle.cpp"],
-        include_dirs=["./third_party/crc32c/include"],
-        libraries=["crc32c"],
         extra_compile_args=extra_compile_args,
         language="c++",
     ),

--- a/src/crackle.hpp
+++ b/src/crackle.hpp
@@ -57,7 +57,7 @@ std::vector<unsigned char> compress_helper(
 	}
 
 	CrackleHeader header(
-		/*format_version=*/0,
+		/*format_version=*/CrackleHeader::current_version,
 		/*label_format=*/label_format,
 		/*crack_format=*/crack_format,
 		/*is_signed=*/is_signed,
@@ -206,7 +206,7 @@ std::vector<uint64_t> get_crack_code_offsets(
 	const CrackleHeader &header,
 	const std::span<const unsigned char> &binary
 ) {
-	uint64_t offset = CrackleHeader::header_size;
+	uint64_t offset = header.header_bytes();
 
 	const uint64_t z_width = sizeof(uint32_t);
 	const uint64_t zindex_bytes = z_width * header.sz;
@@ -421,7 +421,7 @@ LABEL* decompress(
 
 	const CrackleHeader header(buffer);
 
-	if (header.format_version > 0) {
+	if (header.format_version > CrackleHeader::current_version) {
 		std::string err = "crackle: Invalid format version.";
 		err += std::to_string(header.format_version);
 		throw std::runtime_error(err);
@@ -601,7 +601,7 @@ point_cloud(
 
 	const CrackleHeader header(buffer);
 
-	if (header.format_version > 0) {
+	if (header.format_version > CrackleHeader::current_version) {
 		std::string err = "crackle: Invalid format version.";
 		err += std::to_string(header.format_version);
 		throw std::runtime_error(err);
@@ -756,7 +756,7 @@ decode_slice_vcg(
 
 	const CrackleHeader header(buffer);
 
-	if (header.format_version > 0) {
+	if (header.format_version > CrackleHeader::current_version) {
 		std::string err = "crackle: Invalid format version.";
 		err += std::to_string(header.format_version);
 		throw std::runtime_error(err);
@@ -823,7 +823,7 @@ std::vector<unsigned char> reencode_with_markov_order(
 
 	CrackleHeader header(buffer);
 
-	if (header.format_version > 0) {
+	if (header.format_version > CrackleHeader::current_version) {
 		std::string err = "crackle: Invalid format version.";
 		err += std::to_string(header.format_version);
 		throw std::runtime_error(err);

--- a/src/crackle.hpp
+++ b/src/crackle.hpp
@@ -77,7 +77,8 @@ std::vector<unsigned char> compress_helper(
 		/*num_label_bytes=*/0,
 		/*fortran_order*/fortran_order,
 		/*markov_model_order=*/markov_model_order, // 0 is disabled
-		/*is_sorted=*/true
+		/*is_sorted=*/true,
+		/*crc=*/0xFFFF // will be recalculated on saving
 	);
 
 	if (voxels == 0) {

--- a/src/crackle.hpp
+++ b/src/crackle.hpp
@@ -78,7 +78,7 @@ std::vector<unsigned char> compress_helper(
 		/*fortran_order*/fortran_order,
 		/*markov_model_order=*/markov_model_order, // 0 is disabled
 		/*is_sorted=*/true,
-		/*crc=*/0xFFFF // will be recalculated on saving
+		/*crc=*/0xFF // will be recalculated on saving
 	);
 
 	if (voxels == 0) {

--- a/src/lib.hpp
+++ b/src/lib.hpp
@@ -6,29 +6,6 @@ namespace lib {
 
 // Code from stackoverflow by Dr. Mark Adler
 // https://stackoverflow.com/questions/10564491/function-to-calculate-a-crc16-checksum#comment83704063_10569892
-// Polynomial 0xac9a is selected as "best" for messages up to
-// 241 bits and gives a guarantee of detecting up to 4 bit flips
-// according to Phil Koopman. By coincidence, this polynomial
-// is palindromic, so works for both little and big endian.
-// https://users.ece.cmu.edu/~koopman/crc/
-uint16_t crc16(uint8_t const *data, uint64_t size) {
-	// use implicit +1 representation for right shift, LSB first
-	// use explicit +1 representation for left shit, MSB first
-	constexpr uint16_t polynomial = 0xac9a; // implicit
-	uint16_t crc = 0xFFFF; // detects zeroed data better than 0x0000
-	while (size--) {
-		crc ^= *data++;
-		for (unsigned int k = 0; k < 8; k++) {
-			crc = crc & 1
-				? (crc >> 1) ^ polynomial
-				: crc >> 1;
-		}
-	}
-	return crc;
-}
-
-// Code from stackoverflow by Dr. Mark Adler
-// https://stackoverflow.com/questions/10564491/function-to-calculate-a-crc16-checksum#comment83704063_10569892
 // Polynomial 0xe7 is selected as "best" for messages up to
 // 247 bits and gives a guarantee of detecting up to 2 bit flips
 // according to Phil Koopman.

--- a/src/lib.hpp
+++ b/src/lib.hpp
@@ -11,11 +11,32 @@ namespace lib {
 // according to Phil Koopman. By coincidence, this polynomial
 // is palindromic, so works for both little and big endian.
 // https://users.ece.cmu.edu/~koopman/crc/
-uint16_t crc16(uint8_t const *data, size_t size) {
+uint16_t crc16(uint8_t const *data, uint64_t size) {
 	// use implicit +1 representation for right shift, LSB first
 	// use explicit +1 representation for left shit, MSB first
 	constexpr uint16_t polynomial = 0xac9a; // implicit
 	uint16_t crc = 0xFFFF; // detects zeroed data better than 0x0000
+	while (size--) {
+		crc ^= *data++;
+		for (unsigned int k = 0; k < 8; k++) {
+			crc = crc & 1
+				? (crc >> 1) ^ polynomial
+				: crc >> 1;
+		}
+	}
+	return crc;
+}
+
+// Code from stackoverflow by Dr. Mark Adler
+// https://stackoverflow.com/questions/10564491/function-to-calculate-a-crc16-checksum#comment83704063_10569892
+// Polynomial 0xe7 is selected as "best" for messages up to
+// 247 bits and gives a guarantee of detecting up to 2 bit flips
+// according to Phil Koopman.
+uint8_t crc8(uint8_t const *data, uint64_t size) {
+	// use implicit +1 representation for right shift, LSB first
+	// use explicit +1 representation for left shit, MSB first
+	constexpr uint8_t polynomial = 0xe7; // implicit
+	uint8_t crc = 0xFF; // detects zeroed data better than 0x00
 	while (size--) {
 		crc ^= *data++;
 		for (unsigned int k = 0; k < 8; k++) {

--- a/src/lib.hpp
+++ b/src/lib.hpp
@@ -4,6 +4,29 @@
 namespace crackle {
 namespace lib {
 
+// Code from stackoverflow by Dr. Mark Adler
+// https://stackoverflow.com/questions/10564491/function-to-calculate-a-crc16-checksum#comment83704063_10569892
+// Polynomial 0xac9a is selected as "best" for messages up to
+// 241 bits and gives a guarantee of detecting up to 4 bit flips
+// according to Phil Koopman. By coincidence, this polynomial
+// is palindromic, so works for both little and big endian.
+// https://users.ece.cmu.edu/~koopman/crc/
+uint16_t crc16(uint8_t const *data, size_t size) {
+	// use implicit +1 representation for right shift, LSB first
+	// use explicit +1 representation for left shit, MSB first
+	constexpr uint16_t polynomial = 0xac9a; // implicit
+	uint16_t crc = 0xFFFF; // detects zeroed data better than 0x0000
+	while (size--) {
+		crc ^= *data++;
+		for (unsigned int k = 0; k < 8; k++) {
+			crc = crc & 1
+				? (crc >> 1) ^ polynomial
+				: crc >> 1;
+		}
+	}
+	return crc;
+}
+
 // d is for dynamic
 inline uint64_t itocd(uint64_t x, std::vector<unsigned char> &buf, uint64_t idx, int byte_width) { 
 	for (int i = 0; i < byte_width; i++) {


### PR DESCRIPTION
Backwards compatible with Format Version 0.

- Extends num_labels_bytes field from u32 to u64 to handle huge datasets
- Adds CRC8 to protect the header field.

CRC8:
    - using initialization 0xFF
    - Selected from https://users.ece.cmu.edu/~koopman/crc/ to detect up to 2 bit flips for up to 247 bits.
    - Using implicit polynomial 0xe7
    - CRC8 will have, assuming independent probabilities of bit flips, a 4.1% false positive rate for a single bit flip (It's protecting 184 bits. `8 / (184+8) = 4.1%`), or a 95.9% true positive rate for a single bit flip.

Future format versions will include protections for labels and crack codes. It is a bit more work to modify the bitstream, ensure the function is fast enough so that it doesn't impact performance significantly, and integrate e.g. google/crc32c which will require adding cmake to the build.