### PR TITLE
perf: faster crack code construction

### DIFF
--- a/automated_test.py
+++ b/automated_test.py
@@ -655,6 +655,17 @@ def test_spurious_branch_elimination():
 
   assert np.all(recovered == arr)
 
+  arr = np.array([
+    [  0, 139, 139, 139, 139],
+    [  0, 139,   0, 139, 139],
+    [  0, 161,   0,   0, 161],
+    [161, 161, 161, 161, 161],
+  ], dtype=np.uint8).T
+  binary = crackle.compress(arr)
+  recovered = crackle.decompress(binary)[:,:,0]
+
+  assert np.all(recovered == arr)
+
 
 
 

--- a/automated_test.py
+++ b/automated_test.py
@@ -637,6 +637,24 @@ def test_voxel_counts():
   assert vc_cts == cts_gt
 
 
+def test_spurious_branch_elimination():
+  arr = np.array([
+    [0,0,0,0,0,0,0,0,0,0],
+    [0,0,0,0,0,0,0,0,0,0],
+    [0,0,1,1,2,2,0,0,0,0],
+    [0,0,1,1,2,2,0,0,0,0],
+    [0,0,4,4,3,3,0,0,0,0],
+    [0,0,4,4,3,3,0,0,0,0],
+    [0,0,0,0,0,0,0,0,0,0],
+    [0,0,0,0,0,0,0,0,0,0],
+    [0,0,0,0,0,0,0,0,0,0],
+  ], dtype=np.uint8).T
+
+  binary = crackle.compress(arr)
+  recovered = crackle.decompress(binary)[:,:,0]
+
+  assert np.all(recovered == arr)
+
 
 
 

--- a/src/crackcodes.hpp
+++ b/src/crackcodes.hpp
@@ -378,6 +378,8 @@ create_crack_codes(
 
 	std::vector<int64_t> revisit;
 	revisit.reserve(sx);
+	robin_hood::unordered_node_map<int64_t, std::vector<int64_t>> revisit_index;
+	revisit_index.reserve(sx);
 	std::vector<uint8_t> revisit_ct((sx+1)*(sy+1));
 
 	int64_t start_node = 0;
@@ -401,6 +403,7 @@ create_crack_codes(
 					node = revisit.back();
 					revisit.pop_back();
 					if (node > -1) {
+						revisit_index[node].pop_back();
 						revisit_ct[node]--;
 						break;
 					}
@@ -415,6 +418,7 @@ create_crack_codes(
 			else if (popcount(G.adjacency[node]) > 1) {
 				code.push_back('b');
 				revisit.push_back(node);
+				revisit_index[node].push_back(revisit.size() - 1);
 				revisit_ct[node]++;
 				branch_nodes[node].push_back(code.size() - 1);
 				branches_taken++;
@@ -433,13 +437,10 @@ create_crack_codes(
 			// remove it from revisit and replace the branch. 
 			// with a skip.
 			if (revisit_ct[node]) {
-				int64_t pos = revisit.size() - 1;
-				for (; pos >= 0; pos--) {
-					if (revisit[pos] == node) {
-						break;
-					}
-				}
+				int64_t pos = revisit_index[node].back();
+				revisit_index[node].pop_back();
 				revisit[pos] = -1;
+
 				branches_taken--;
 				code[branch_nodes[node].back()] = 's';
 				branch_nodes[node].pop_back();

--- a/src/crackcodes.hpp
+++ b/src/crackcodes.hpp
@@ -271,33 +271,24 @@ int64_t remove_initial_branch(
 void remove_spurious_branches(
 	std::vector<unsigned char>& code
 ) {
-	for (int i = 0; i < code.size(); i++) {
-		printf("%c [%d], ", code[i], i);
-	}
-	printf("\n");
-
 	std::vector<int64_t> branch_stack;
 	branch_stack.push_back(-1);
 
-	std::vector<int64_t> branch_lens(code.size() + 1);
+	std::vector<uint32_t> branch_lens(code.size() + 1);
 
 	std::vector<std::pair<int64_t,int64_t>> to_erase;
 
 	int64_t current_branch = -1;
-	printf("cb: %d\n", current_branch);
 	for (int64_t i = 0; i < code.size(); i++) {
 		if (code[i] == 'b') {
 			branch_stack.push_back(i);
 		}
 		else if (code[i] == 't') {
-			printf("bc %d len=%d\n", current_branch, branch_lens[current_branch+1]);
 			if (current_branch >= 0 && branch_lens[current_branch+1] == 0) {
 				to_erase.emplace_back(current_branch, i);
 			}
-
-			branch_stack.pop_back();
 			current_branch = branch_stack.back();
-			printf("cb: %d\n", current_branch);
+			branch_stack.pop_back();
 		}
 		else {
 			branch_lens[current_branch+1]++;
@@ -305,15 +296,9 @@ void remove_spurious_branches(
 	}
 
 	for (auto pair : to_erase) {
-		printf("%d %d %c %c\n", pair.first, pair.second, code[pair.first], code[pair.second]);
 		code[pair.first] = 's';
 		code[pair.second] = 's';
 	}
-
-	for (unsigned char c : code) {
-		printf("%c, ", c);
-	}
-	printf("\n");
 }
 
 std::vector<uint64_t> read_boc_index(
@@ -485,7 +470,6 @@ create_crack_codes(
 			start_node, code, sx, sy
 		);
 
-		printf("start: %d\n", adjusted_start_node);
 		remove_spurious_branches(code);
 
 		chains.push_back(


### PR DESCRIPTION
For large watershed volumes, there was a quadratic algorithm that was insignificant at smaller sizes but caused compression to take thousands of seconds. Now it takes ~5 seconds and we've removed various hashmap accesses.

We were trying to avoid adding spurious branches to the crack code, but it's faster to just strip them after the fact.