### PR TITLE
perf: in-place c++ remap operator

### DIFF
--- a/src/crc.hpp
+++ b/src/crc.hpp
@@ -7,6 +7,9 @@
 	#include "crc32c_x86_64_sse.h"
 #endif
 
+#include <vector>
+#include <span>
+
 namespace crackle {
 namespace crc {
 
@@ -32,6 +35,14 @@ uint8_t crc8(uint8_t const *data, uint64_t size) {
 }
 
 uint32_t crc32c(const std::vector<unsigned char>& data) {
+	return crc32_impl(0x0000, data.data(), data.size());
+}
+
+uint32_t crc32c(const std::span<unsigned char>& data) {
+	return crc32_impl(0x0000, data.data(), data.size());
+}
+
+uint32_t crc32c(const std::span<const unsigned char>& data) {
 	return crc32_impl(0x0000, data.data(), data.size());
 }
 

--- a/src/header.hpp
+++ b/src/header.hpp
@@ -203,7 +203,7 @@ public:
 		return ngrids;
 	}
 
-	size_t tochars(std::vector<unsigned char> &buf, size_t idx = 0) const {
+	size_t tochars(std::span<unsigned char> buf, size_t idx = 0) const {
 		if ((idx + header_bytes()) > buf.size()) {
 			throw std::runtime_error("crackle: Unable to write past end of buffer.");
 		}

--- a/src/labels.hpp
+++ b/src/labels.hpp
@@ -16,6 +16,17 @@
 namespace crackle {
 namespace labels {
 
+// For pin encodings only, extract the background color.
+uint64_t background_color(std::span<unsigned char> binary) {
+	crackle::CrackleHeader header(binary);
+
+	if (header.label_format == LabelFormat::FLAT) {
+		throw std::runtime_error("Background color can only be extracted from pin encoded streams.");
+	}
+	uint64_t offset = header.header_bytes() + header.grid_index_bytes();
+	return crackle::lib::ctoid(binary, offset, header.stored_data_width);
+}
+
 template <typename LABEL, typename STORED_LABEL>
 std::tuple<
 	std::vector<unsigned char>,

--- a/src/lib.hpp
+++ b/src/lib.hpp
@@ -2,12 +2,13 @@
 #define __CRACKLE_LIB_HXX__
 
 #include <vector>
+#include <span>
 
 namespace crackle {
 namespace lib {
 
 // d is for dynamic
-inline uint64_t itocd(uint64_t x, std::vector<unsigned char> &buf, uint64_t idx, int byte_width) { 
+inline uint64_t itocd(uint64_t x, std::span<unsigned char> buf, uint64_t idx, int byte_width) { 
 	for (int i = 0; i < byte_width; i++) {
 		buf[idx + i] = static_cast<unsigned char>(
 			(x >> (8*i)) & 0xFF
@@ -18,18 +19,18 @@ inline uint64_t itocd(uint64_t x, std::vector<unsigned char> &buf, uint64_t idx,
 
 // little endian serialization of integers to chars
 // returns bytes written
-inline uint64_t itoc(uint8_t x, std::vector<unsigned char> &buf, uint64_t idx) {
+inline uint64_t itoc(uint8_t x, std::span<unsigned char> buf, uint64_t idx) {
 	buf[idx] = x;
 	return 1;
 }
 
-inline uint64_t itoc(uint16_t x, std::vector<unsigned char> &buf, uint64_t idx) {
+inline uint64_t itoc(uint16_t x, std::span<unsigned char> buf, uint64_t idx) {
 	buf[idx + 0] = x & 0xFF;
 	buf[idx + 1] = (x >> 8) & 0xFF;
 	return 2;
 }
 
-inline uint64_t itoc(uint32_t x, std::vector<unsigned char> &buf, uint64_t idx) {
+inline uint64_t itoc(uint32_t x, std::span<unsigned char> buf, uint64_t idx) {
 	buf[idx + 0] = x & 0xFF;
 	buf[idx + 1] = (x >> 8) & 0xFF;
 	buf[idx + 2] = (x >> 16) & 0xFF;
@@ -37,7 +38,7 @@ inline uint64_t itoc(uint32_t x, std::vector<unsigned char> &buf, uint64_t idx) 
 	return 4;
 }
 
-inline uint64_t itoc(uint64_t x, std::vector<unsigned char> &buf, uint64_t idx) {
+inline uint64_t itoc(uint64_t x, std::span<unsigned char> buf, uint64_t idx) {
 	buf[idx + 0] = x & 0xFF;
 	buf[idx + 1] = (x >> 8) & 0xFF;
 	buf[idx + 2] = (x >> 16) & 0xFF;


### PR DESCRIPTION
This loses some of the fastremap optimizations,
but gains the ability to directly modify the bytestream and avoids many copies.