### PR TITLE
feat: add bounding boxes call

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,17 @@ jobs:
           python -m pip install pytest -r requirements.txt -r requirements-dev.txt
 
       - name: Compile
-        run: python setup.py develop
-
+        run: |
+          if [ "${{ matrix.os }}" == "macos-latest" ]; then
+            if [ "$RUNNER_ARCH" == "X64" ]; then
+                export ARCHFLAGS="-arch x86_64"
+            elif [ "$RUNNER_ARCH" == "ARM64" ]; then
+                export ARCHFLAGS="-arch arm64"
+            else
+                echo "Unsupported architecture $RUNNER_ARCH"
+                exit 1
+            fi
+          fi
+          python setup.py develop
       - name: Test with pytest
         run: pytest -v -x automated_test.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,9 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pytest -r requirements.txt -r requirements-dev.txt
 
-      - name: Compile
+      - name: Compile (macOS/Linux)
+        if: matrix.os != 'windows-latest'
+        shell: bash
         run: |
           if [ "${{ matrix.os }}" == "macos-latest" ]; then
             if [ "$RUNNER_ARCH" == "X64" ]; then
@@ -44,5 +46,10 @@ jobs:
             fi
           fi
           python setup.py develop
+
+      - name: Compile (Windows)
+        if: matrix.os == 'windows-latest'
+        run: python setup.py develop
+      
       - name: Test with pytest
         run: pytest -v -x automated_test.py

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ ptc = crackle.point_cloud(binary)
 # rapid and low memory
 voxel_counts = crackle.voxel_counts(binary)
 centroids = crackle.centroids(binary)
+bbxes = crackle.bounding_boxes(binary)
 
 # building big arrays with low memory
 binary = crackle.zeros([5000,5000,5000], dtype=np.uint64, order='F')

--- a/automated_test.py
+++ b/automated_test.py
@@ -796,6 +796,28 @@ def test_centroids():
     if i > 20:
       break
 
+def test_bounding_boxes():
+  import scipy.ndimage
+  import fastremap 
+
+  labels = compresso.load("connectomics.npy.cpso.gz")
+
+  binary = crackle.compress(labels)
+  bbxes = crackle.bounding_boxes(binary)
+
+  import pdb; pdb.set_trace()
+
+  labels, _ = fastremap.renumber(labels, in_place=True)
+
+  binary = crackle.compress(labels)
+
+  crackle_slices = crackle.bounding_boxes(binary)
+  scipy_slices = scipy.ndimage.find_objects(labels)
+
+  for i, scipy_slc in enumerate(scipy_slices):
+    ckl_slc = crackle_slices[i+1]
+    assert ckl_slc == scipy_slc
+
 def test_spurious_branch_elimination():
   arr = np.array([
     [0,0,0,0,0,0,0,0,0,0],

--- a/automated_test.py
+++ b/automated_test.py
@@ -802,11 +802,6 @@ def test_bounding_boxes():
 
   labels = compresso.load("connectomics.npy.cpso.gz")
 
-  binary = crackle.compress(labels)
-  bbxes = crackle.bounding_boxes(binary)
-
-  import pdb; pdb.set_trace()
-
   labels, _ = fastremap.renumber(labels, in_place=True)
 
   binary = crackle.compress(labels)

--- a/crackle/__init__.py
+++ b/crackle/__init__.py
@@ -42,7 +42,7 @@ from .codec import (
 	compress, decompress, labels,
 	nbytes, components, component_lengths,
 	header, contains, crack_codes, num_labels,
-	point_cloud, voxel_counts, centroids,
+	point_cloud, voxel_counts, centroids, bounding_boxes,
 )
 from .operations import (
 	astype, ascontiguousarray, asfortranarray,

--- a/crackle/array.py
+++ b/crackle/array.py
@@ -67,14 +67,23 @@ class CrackleArray:
   def num_labels(self) -> int:
     return num_labels(self.binary)
 
-  def voxel_counts(self) -> dict:
-    return voxel_counts(self.binary, parallel=self.parallel)
+  def voxel_counts(self, label:Optional[int] = None) -> dict:
+    return voxel_counts(self.binary, label=label, parallel=self.parallel)
 
-  def centroids(self) -> dict:
-    return centroids(self.binary, parallel=self.parallel)
+  def centroids(self, label:Optional[int] = None) -> dict:
+    return centroids(self.binary, label=label, parallel=self.parallel)
 
-  def bounding_boxes(self) -> dict:
-    return bounding_boxes(self.binary, parallel=self.parallel)
+  def bounding_boxes(
+    self, 
+    label:Optional[int] = None, 
+    no_slice_conversion:bool = False,
+  ) -> dict:
+    return bounding_boxes(
+      self.binary, 
+      label=label, 
+      no_slice_conversion=no_slice_conversion,
+      parallel=self.parallel
+    )
 
   def min(self) -> int:
     return codec.min(self.binary)

--- a/crackle/array.py
+++ b/crackle/array.py
@@ -6,7 +6,7 @@ from .codec import (
   labels, nbytes, contains, 
   header, crack_codes, num_labels,
   components, point_cloud, voxel_counts,
-  centroids,
+  centroids, bounding_boxes,
 )
 from .operations import (
   astype,
@@ -72,6 +72,9 @@ class CrackleArray:
 
   def centroids(self) -> dict:
     return centroids(self.binary, parallel=self.parallel)
+
+  def bounding_boxes(self) -> dict:
+    return bounding_boxes(self.binary, parallel=self.parallel)
 
   def min(self) -> int:
     return codec.min(self.binary)

--- a/crackle/codec.py
+++ b/crackle/codec.py
@@ -913,6 +913,13 @@ def bounding_boxes(
 
   If "label" is provided, compute only that label which
   may save some computaton.
+
+  no_slice_conversion will avoid converting 
+    [xmin, ymin, zmin, xmax, ymax, zmax]
+    into
+    (slice(xmin,xmax+1), slice(ymin,ymax+1), slice(zmin,zmax+1)
+
+    Which can save time and may be in a more desirable format.
   """
   if label is None:
     z_start = 0

--- a/crackle/codec.py
+++ b/crackle/codec.py
@@ -902,7 +902,7 @@ def centroids(
 def bounding_boxes(
   binary:bytes, 
   label:Optional[int] = None,
-  parallel:int = 1,
+  parallel:int = 0,
   no_slice_conversion:bool = False,
 ) -> Union[
   dict[int,tuple[int,int,int,int,int,int]],

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 cloud-volume
 compresso
+fastremap
 pytest
 networkx
 tqdm

--- a/src/labels.hpp
+++ b/src/labels.hpp
@@ -390,6 +390,37 @@ std::span<const STORED_LABEL> decode_uniq(
 	);
 }
 
+std::vector<uint64_t> unique(const std::span<const unsigned char> &binary) {
+	const CrackleHeader header(binary);
+	std::span<const unsigned char> labels_binary = raw_labels(binary);
+	const uint64_t N = decode_num_labels(header, labels_binary);
+	std::vector<uint64_t> lbls;
+	lbls.reserve(N);
+
+	if (header.stored_data_width == 1) {
+		for (uint8_t l : decode_uniq<uint8_t>(header, labels_binary)) {
+			lbls.push_back(static_cast<uint64_t>(l));
+		}
+	}
+	else if (header.stored_data_width == 2) {
+		for (uint16_t l : decode_uniq<uint16_t>(header, labels_binary)) {
+			lbls.push_back(static_cast<uint64_t>(l));
+		}
+	}
+	else if (header.stored_data_width == 4) {
+		for (uint32_t l : decode_uniq<uint32_t>(header, labels_binary)) {
+			lbls.push_back(static_cast<uint64_t>(l));
+		}
+	}
+	else {
+		for (uint64_t l : decode_uniq<uint64_t>(header, labels_binary)) {
+			lbls.push_back(static_cast<uint64_t>(l));
+		}
+	}
+
+	return lbls;
+}
+
 std::tuple<
 	std::vector<uint64_t>,
 	uint64_t,

--- a/src/operations.hpp
+++ b/src/operations.hpp
@@ -577,6 +577,201 @@ auto centroids(
 	);
 }
 
+template <typename LABEL>
+std::unordered_map<uint64_t, std::array<uint32_t, 6>>
+bounding_boxes(
+	const unsigned char* buffer, 
+	const size_t num_bytes,
+	int64_t z_start = -1,
+	int64_t z_end = -1,
+	size_t parallel = 1
+) {
+	if (num_bytes < CrackleHeader::header_size) {
+		std::string err = "crackle: Input too small to be a valid stream. Bytes: ";
+		err += std::to_string(num_bytes);
+		throw std::runtime_error(err);
+	}
+
+	const CrackleHeader header(buffer);
+
+	const uint64_t sx = header.sx;
+	const uint64_t sy = header.sy;
+	const uint64_t sz = header.sz;
+	const uint64_t sxy = header.sx * header.sy;
+
+	if (header.format_version > CrackleHeader::current_version) {
+		std::string err = "crackle: Invalid format version.";
+		err += std::to_string(header.format_version);
+		throw std::runtime_error(err);
+	}
+
+	z_start = std::max(std::min(z_start, static_cast<int64_t>(sz - 1)), static_cast<int64_t>(0));
+	z_end = z_end < 0 ? static_cast<int64_t>(sz) : z_end;
+	z_end = std::max(std::min(z_end, static_cast<int64_t>(sz)), static_cast<int64_t>(0));
+
+	if (z_start >= z_end) {
+		std::string err = "crackle: Invalid range: ";
+		err += std::to_string(z_start);
+		err += std::string(" - ");
+		err += std::to_string(z_end);
+		throw std::runtime_error(err);
+	}
+
+	const int64_t szr = z_end - z_start;
+
+	const uint64_t voxels = (
+		static_cast<uint64_t>(sx) 
+		* static_cast<uint64_t>(sy) 
+		* static_cast<uint64_t>(szr)
+	);
+
+	if (voxels == 0) {
+		return std::unordered_map<uint64_t, std::array<uint32_t,6>>();
+	}
+
+	std::span<const unsigned char> binary(buffer, num_bytes);
+
+	// only used for markov compressed streams
+	std::vector<std::vector<uint8_t>> markov_model = decode_markov_model(header, binary);
+	
+	auto crack_codes = get_crack_codes(header, binary, z_start, z_end);
+
+	uint64_t num_labels = crackle::labels::num_labels(binary);
+	std::unordered_map<uint64_t, std::array<uint32_t, 6>> bbxes; // label: xmin,ymin,zmin,xmax,ymax,zmax
+	bbxes.reserve(num_labels);
+
+	std::vector<uint64_t> uniq = crackle::labels::unique(binary);
+	for (auto lbl : uniq) {
+		auto& bbx = bbxes[lbl];
+		bbx[0] = std::numeric_limits<uint32_t>::max();
+		bbx[1] = std::numeric_limits<uint32_t>::max();
+		bbx[2] = std::numeric_limits<uint32_t>::max();
+	}
+
+	if (parallel == 0) {
+		parallel = std::thread::hardware_concurrency();
+	}
+	parallel = std::min(parallel, static_cast<size_t>(szr));
+
+	ThreadPool pool(parallel);
+
+	std::vector<std::vector<uint8_t>> vcgs(parallel);
+	std::vector<std::vector<uint32_t>> ccls(parallel);
+
+	for (size_t t = 0; t < parallel; t++) {
+		vcgs[t].resize(sxy);
+		ccls[t].resize(sxy);
+	}
+
+	std::mutex mtx;
+	for (size_t z = z_start, i = 0; i < crack_codes.size(); z++, i++) {
+		pool.enqueue([&,z,i](size_t t){
+			std::vector<uint8_t>& vcg = vcgs[t];
+			std::vector<uint32_t>& ccl = ccls[t];
+			auto& crack_code = crack_codes[i];
+
+			crack_code_to_vcg(
+				/*code=*/crack_code,
+				/*sx=*/sx, /*sy=*/sy,
+				/*permissible=*/(header.crack_format == CrackFormat::PERMISSIBLE),
+				/*markov_model=*/markov_model,
+				/*slice_edges=*/vcg.data()
+			);
+
+			uint64_t N = 0;
+			crackle::cc3d::color_connectivity_graph<uint32_t>(
+				vcg, sx, sy, 1, ccl.data(), N
+			);
+
+			std::vector<LABEL> label_map = decode_label_map<LABEL>(
+				header, binary, ccl.data(), N, z, z+1
+			);
+			std::vector<std::array<uint32_t, 4>> slice_bbxs(N);
+
+			for (uint64_t i = 0; i < N; i++) {
+				slice_bbxs[i][0] = std::numeric_limits<uint32_t>::max(); // xmin
+				slice_bbxs[i][1] = std::numeric_limits<uint32_t>::max(); // ymin
+			}
+
+			for (uint64_t y = 0; y < header.sy; y++) {
+				for (uint64_t x = 0; x < header.sx; x++) {
+					uint32_t ccl_label = ccl[x + sx * y];
+
+					auto& bbx = slice_bbxs[ccl_label];
+
+					bbx[0] = std::min(bbx[0], static_cast<uint32_t>(x));
+					bbx[1] = std::min(bbx[1], static_cast<uint32_t>(y));
+					bbx[2] = std::max(bbx[2], static_cast<uint32_t>(x));
+					bbx[3] = std::max(bbx[3], static_cast<uint32_t>(y));
+				}
+			}
+
+			std::unique_lock<std::mutex> lock(mtx);
+			for (uint64_t i = 0; i < N; i++) {
+				auto& bbx = bbxes[label_map[i]];
+				bbx[0] = std::min(bbx[0], slice_bbxs[i][0]);
+				bbx[1] = std::min(bbx[1], slice_bbxs[i][1]);
+				bbx[2] = std::min(bbx[2], static_cast<uint32_t>(z));
+				bbx[3] = std::max(bbx[3], slice_bbxs[i][2]);
+				bbx[4] = std::max(bbx[4], slice_bbxs[i][3]);
+				bbx[5] = std::max(bbx[5], static_cast<uint32_t>(z));
+			}
+		});
+	}
+
+	pool.join();
+
+	return bbxes;
+}
+
+auto bounding_boxes(
+	const unsigned char* buffer, 
+	const size_t num_bytes,
+	int64_t z_start = -1,
+	int64_t z_end = -1,
+	size_t parallel = 1
+) {
+	CrackleHeader header(buffer);
+
+	if (header.data_width == 1) {
+		return bounding_boxes<uint8_t>(
+			buffer, num_bytes,
+			z_start, z_end, parallel
+		);
+	}
+	else if (header.data_width == 2) {
+		return bounding_boxes<uint16_t>(
+			buffer, num_bytes,
+			z_start, z_end, parallel
+		);
+	}
+	else if (header.data_width == 4) {
+		return bounding_boxes<uint32_t>(
+			buffer, num_bytes,
+			z_start, z_end, parallel
+		);
+	}
+	else {
+		return bounding_boxes<uint64_t>(
+			buffer, num_bytes,
+			z_start, z_end, parallel
+		);
+	}
+}
+
+auto bounding_boxes(
+	const std::span<const unsigned char>& buffer,
+	const int64_t z_start = -1, 
+	const int64_t z_end = -1,
+	size_t parallel = 1
+) {
+	return bounding_boxes(
+		buffer.data(),
+		buffer.size(),
+		z_start, z_end, parallel
+	);
+}
+
 
 };
 };


### PR DESCRIPTION
Extract the bounding boxes using only a few slices worth of memory.

```python
bbxs = crackle.bounding_boxes(binary)
arr = crackle.CrackleArray(binary)
bbxs = arr.bounding_boxes()
```