### PR TITLE
feat: sidecar file for accelerated voxel count and bounding box access

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ before, middle, after = crackle.zsplit(binary, z=742)
 sections = crackle.zshatter(binary)
 ```
 
-*This repository is currently Beta. It works and the format is reasonably fixed. There may be some improvements down the line (such as 3d compression of crack codes), but they will be a new format version number.*
+*This repository is currently Beta. It works and the format is reasonably fixed. There may be some improvements down the line (such as 3d compression of crack codes, 2d chunking), but they will be a new format version number if necessary to retain backwards compatibility.*
 
 Crackle is a compression codec for 3D dense segmentation (labeled) images. The algorithm accepts both signed and unsigned integer labels (though the implementation currently has some restrictions on signed integers). It is written in C++ and has Python bindings. Crackle uses a two pass compression strategy where the output of crackle may be further comrpessed with a bitstream compressor like gzip, bzip2, zstd, or lzma. However, if the Crackle binary, which is already small, is not further compressed, it supports several efficient operations:
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,49 @@ Crackle improves upon Compresso by replacing the bit-packed boundary map with a 
 
 See benchmarks for more information on Crackle's size and compute effiency.
 
+## Optional Performance Enhancing Sidecar `.ckl.meta.parquet` File
+
+Counting voxels or measuring bounding boxes is fully supported by the bare crackle file, but requires computation which on large images or numerous images can become substantial. Therefore, crackle comes with a facility for generating a `.parquet` file containing this metadata information for faster retrieval. Currently, to avoid engineering complexity, crackle does not make use of this file, so use pyarrow, duckdb, or similar to read it. This extra file adds nothing except performance enhancement for some use cases. **All data can be generated from the crackle file alone, and nothing is lost if the sidecar file is lost.**
+
+You will need pyarrow installed to generate this file: `pip install pyarrow`
+
+```bash
+crackle -M myfile.ckl # generates myfile.ckl.meta.parquet
+```
+
+```python
+import crackle
+
+arr = crackle.aload("myfile.ckl")
+arr.cache_meta("myfile.ckl.meta.parquet") # generate the sidecar file
+```
+
+You can then read the parquet files using your favorite parquet reader. Sometimes it is faster to use crackle methods on single files, but when tested on hundreds of thousands of files, reading voxel counts out of parquet was 100x faster (20 files per second versus 2000 on a Macbook M3).
+
+### Parquet Schema
+
+Bbox type is uint16 unless the xy dimensions of the crackle file exceed 16-bits (65,535) in which case it is uint32.
+
+```
+label: uint64
+voxel_count: uint32
+min_x: uint16 or uint32
+max_x: uint16 or uint32
+min_y: uint16 or uint32
+max_y: uint16 or uint32
+# if it's a 3d crackle file
+min_z: uint16 or uint32
+max_z: uint16 or uint32
+```
+
+### Reading Example
+
+```python
+import pyarrow.parquet as pq
+table = pq.read_table("myfile.ckl.meta.parquet")
+print(table)
+```
+
 ## Installation
 
 ```bash

--- a/crackle/__init__.py
+++ b/crackle/__init__.py
@@ -43,7 +43,7 @@ from .codec import (
 	nbytes, components, component_lengths,
 	header, contains, contains_range, crack_codes, num_labels,
 	point_cloud, voxel_counts, centroids, bounding_boxes,
-	each,
+	each, cache_meta,
 )
 from .operations import (
 	astype, ascontiguousarray, asfortranarray,

--- a/crackle/array.py
+++ b/crackle/array.py
@@ -6,7 +6,7 @@ from .codec import (
   labels, nbytes, contains, contains_range,
   header, crack_codes, num_labels,
   components, point_cloud, voxel_counts,
-  centroids, bounding_boxes, each,
+  centroids, bounding_boxes, each, cache_meta,
 )
 from .operations import (
   astype,
@@ -163,6 +163,9 @@ class CrackleArray:
     anisotropy:tuple[float,float,float] = (1.0,1.0,1.0),
   ) -> dict[tuple[int,int],float]:
     return contacts(self.binary, anisotropy=anisotropy)
+
+  def cache_meta(self, filelike):
+    return cache_meta(self.binary, filelike, parallel=self.parallel)
 
   def save(self, filelike):
     import crackle.util

--- a/crackle/codec.py
+++ b/crackle/codec.py
@@ -1092,7 +1092,7 @@ def each(
   else:
     return BinaryImageIterator()
 
-def cache_meta(binary:bytes, path:str, parallel:int = 0) -> "pyarrow.parquet.table":
+def cache_meta(binary:bytes, path:str, parallel:int = 0) -> "pyarrow.Table":
   """
   Compute object voxel counts, bounding boxes and save
   them into a parquet file at path.
@@ -1115,27 +1115,43 @@ def cache_meta(binary:bytes, path:str, parallel:int = 0) -> "pyarrow.parquet.tab
   max_y = [ bbxs[label][4] for label in labels ]
   max_z = [ bbxs[label][5] for label in labels ]
 
-  schema = pa.schema([
+  head = header(binary)
+  max_dim = max(head.sx, head.sy, head.sz)
+
+  if max_dim <= np.iinfo(np.uint16).max:
+    bbox_type = pa.uint16()
+  else:
+    bbox_type = pa.uint32()
+
+  schema = [
     pa.field('label', pa.uint64()),
     pa.field('voxel_count', pa.uint32()),
-    pa.field('min_x', pa.uint32()),
-    pa.field('min_y', pa.uint32()),
-    pa.field('min_z', pa.uint32()),
-    pa.field('max_x', pa.uint32()),
-    pa.field('max_y', pa.uint32()),
-    pa.field('max_z', pa.uint32()),
-  ])
+    pa.field('min_x', bbox_type),
+    pa.field('max_x', bbox_type),
+    pa.field('min_y', bbox_type),
+    pa.field('max_y', bbox_type),
+  ]
 
-  table = pa.table({
+  if head.sz > 1:
+    schema.append(pa.field('min_z', bbox_type))
+    schema.append(pa.field('max_z', bbox_type))
+
+  schema = pa.schema(schema)
+
+  rows = {
     'label': labels,
     'voxel_count': cts,
     'min_x': min_x,
-    'min_y': min_y,
-    'min_z': min_z,
     'max_x': max_x,
+    'min_y': min_y,
     'max_y': max_y,
-    'max_z': max_z,
-  }, schema=schema)
+  }
+
+  if head.sz > 1:
+    rows['min_z'] = min_z
+    rows['max_z'] = max_z
+
+  table = pa.table(rows, schema=schema)
 
   pq.write_table(table, path, compression="zstd")
 

--- a/crackle/codec.py
+++ b/crackle/codec.py
@@ -1092,4 +1092,53 @@ def each(
   else:
     return BinaryImageIterator()
 
+def cache_meta(binary:bytes, path:str, parallel:int = 0) -> "pyarrow.parquet.table":
+  """
+  Compute object voxel counts, bounding boxes and save
+  them into a parquet file at path.
+  """
+  import pyarrow as pa
+  import pyarrow.parquet as pq
+
+  cts = voxel_counts(binary, parallel=parallel)
+  # no slice conversion is a performance optimization, we don't need
+  # the bboxes converted to python slices, just as 6 integers
+  bbxs = bounding_boxes(binary, parallel=parallel, no_slice_conversion=True)
+
+  labels = sorted(list(cts.keys()))
+  cts = [ cts[label] for label in labels ]
+
+  min_x = [ bbxs[label][0] for label in labels ]
+  min_y = [ bbxs[label][1] for label in labels ]
+  min_z = [ bbxs[label][2] for label in labels ]
+  max_x = [ bbxs[label][3] for label in labels ]
+  max_y = [ bbxs[label][4] for label in labels ]
+  max_z = [ bbxs[label][5] for label in labels ]
+
+  schema = pa.schema([
+    pa.field('label', pa.uint64()),
+    pa.field('voxel_count', pa.uint32()),
+    pa.field('min_x', pa.uint32()),
+    pa.field('min_y', pa.uint32()),
+    pa.field('min_z', pa.uint32()),
+    pa.field('max_x', pa.uint32()),
+    pa.field('max_y', pa.uint32()),
+    pa.field('max_z', pa.uint32()),
+  ])
+
+  table = pa.table({
+    'label': labels,
+    'voxel_count': cts,
+    'min_x': min_x,
+    'min_y': min_y,
+    'min_z': min_z,
+    'max_x': max_x,
+    'max_y': max_y,
+    'max_z': max_z,
+  }, schema=schema)
+
+  pq.write_table(table, path, compression="zstd")
+
+  return table
+
 

--- a/crackle/codec.py
+++ b/crackle/codec.py
@@ -1105,23 +1105,25 @@ def cache_meta(binary:bytes, path:str, parallel:int = 0) -> "pyarrow.Table":
   # the bboxes converted to python slices, just as 6 integers
   bbxs = bounding_boxes(binary, parallel=parallel, no_slice_conversion=True)
 
-  labels = sorted(list(cts.keys()))
-  cts = [ cts[label] for label in labels ]
-
-  min_x = [ bbxs[label][0] for label in labels ]
-  min_y = [ bbxs[label][1] for label in labels ]
-  min_z = [ bbxs[label][2] for label in labels ]
-  max_x = [ bbxs[label][3] for label in labels ]
-  max_y = [ bbxs[label][4] for label in labels ]
-  max_z = [ bbxs[label][5] for label in labels ]
+  labels = np.asarray(sorted(list(cts.keys())), dtype=np.uint64)
+  cts = np.asarray([ cts[label] for label in labels ], dtype=np.uint32)
 
   head = header(binary)
   max_dim = max(head.sx, head.sy, head.sz)
 
   if max_dim <= np.iinfo(np.uint16).max:
     bbox_type = pa.uint16()
+    bbox_dtype = np.uint16
   else:
     bbox_type = pa.uint32()
+    bbox_dtype = np.uint32
+
+  min_x = np.asarray([ bbxs[label][0] for label in labels ], dtype=bbox_dtype)
+  min_y = np.asarray([ bbxs[label][1] for label in labels ], dtype=bbox_dtype)
+  min_z = np.asarray([ bbxs[label][2] for label in labels ], dtype=bbox_dtype)
+  max_x = np.asarray([ bbxs[label][3] for label in labels ], dtype=bbox_dtype)
+  max_y = np.asarray([ bbxs[label][4] for label in labels ], dtype=bbox_dtype)
+  max_z = np.asarray([ bbxs[label][5] for label in labels ], dtype=bbox_dtype)
 
   schema = [
     pa.field('label', pa.uint64()),

--- a/crackle_cli/cli.py
+++ b/crackle_cli/cli.py
@@ -19,26 +19,41 @@ class Tuple3(click.ParamType):
         self.fail(f"'{value}' does not contain a comma delimited list of 3 integers.")
     return value
 
+def normalize_extension(path):
+	path = removesuffix(path, ".lzma")
+	path = removesuffix(path, ".gz")
+	path = removesuffix(path, ".xz")
+	path = removesuffix(path, ".bz2")
+	path = removesuffix(path, ".zstd")
+	return path
+
 @click.command()
 @click.option("-c/-d", "--compress/--decompress", default=True, is_flag=True, help="Compress from or decompress to a numpy .npy file.", show_default=True)
 @click.option('-i', "--info", default=False, is_flag=True, help="Print the header for the file.", show_default=True)
 @click.option('-l', "--labels", default=False, is_flag=True, help="Print unique labels contained in the image.", show_default=True)
 @click.option('-t', "--test", default=False, is_flag=True, help="Check for file corruption and report damaged areas.", show_default=True)
 @click.option('-p', '--allow-pins', default=False, is_flag=True, help="Allow pin encoding.", show_default=True)
-@click.option('-m', '--markov', default=0, help="If >0, use this order of markov compression for the crack code.", show_default=True)
+@click.option('-m', '--markov', default=None, help="If >0, use this order of markov compression for the crack code.", show_default=True)
 @click.option('-k', '--keep', default=False, is_flag=True, help="Keep the original file.", show_default=True)
 @click.option('-z', 'gzip', default=False, is_flag=True, help="Apply gzip compression after encoding.", show_default=True)
+@click.option('-M', '--cache-meta', default=False, is_flag=True, help="Create a sidecar parquet file with voxel counts, bounding boxes with filename .meta.parquet.", show_default=True)
 @click.argument("source", nargs=-1)
-def main(compress, info, test, labels, allow_pins, markov, source, keep, gzip):
+def main(compress, info, test, labels, allow_pins, markov, source, keep, gzip, cache_meta):
 	"""
 	Compress and decompress crackle (.ckl) files to and from numpy (.npy) files.
 
 	Compatible with crackle format version 0 streams.
 	"""
+	orig_markov = markov
+	markov = markov or 0
+
 	for i in range(len(source)):
 		if source[i] == "-":
 			source = source[:i] + sys.stdin.readlines() + source[i+1:]
 	
+	if not compress and not keep and cache_meta:
+		print("Warning: -M/--cache-meta has no effect when decompressing without --keep", file=sys.stderr)
+
 	for src in source:
 		if info:
 			print_header(src)
@@ -50,10 +65,18 @@ def main(compress, info, test, labels, allow_pins, markov, source, keep, gzip):
 			print_labels(src)
 			continue
 
+		if cache_meta and compress and orig_markov is None and normalize_extension(src).endswith('.ckl'):
+			create_sidecar_file(src)
+			continue
+
 		if compress:
-			compress_file(src, allow_pins, markov, gzip, keep)
+			ckl_path = compress_file(src, allow_pins, markov, gzip, keep)
 		else:
-			decompress_file(src, keep)
+			ckl_path = decompress_file(src, keep)
+
+		if cache_meta:
+			if ckl_path:
+				create_sidecar_file(ckl_path)
 
 def check_binary(src):
 	try:
@@ -134,18 +157,24 @@ def print_header(src):
 	print(f"num_labels: {num_labels}")
 	print()
 
+def create_sidecar_file(src):
+	arr = crackle.aload(src, allow_mmap=True)
+	meta_path = normalize_extension(src)
+	meta_path += ".meta.parquet"
+	arr.cache_meta(meta_path)
+
 def decompress_file(src, keep):
 	try:
 		arr = crackle.util.aload(src)
 	except FileNotFoundError:
 		print(f"crackle: File \"{src}\" does not exist.")
-		return
+		return None
 	except crackle.FormatError as err:
 		print("crackle:", err)
-		return
+		return None
 	except crackle.DecodeError:
 		print(f"crackle: {src} could not be decoded.")
-		return
+		return None
 
 	dest = src.replace(".ckl", "").replace(".gz", "").replace(".xz", "").replace(".lzma", "")
 	_, ext = os.path.splitext(dest)
@@ -165,6 +194,11 @@ def decompress_file(src, keep):
 		print(f"crackle: Unable to write {dest}. Aborting.")
 		sys.exit()
 
+	if keep:
+		return src
+	else:
+		return None
+
 def compress_file(src, allow_pins, markov, gzip, keep):
 	is_crackle = False
 	try:
@@ -175,15 +209,13 @@ def compress_file(src, allow_pins, markov, gzip, keep):
 			is_crackle = True
 		except:
 			print(f"crackle: {src} is not a numpy or crackle file.")
-			return
+			return None
 	except FileNotFoundError:
 		print(f"crackle: File \"{src}\" does not exist.")
-		return
+		return None
 
 	orig_src = src
-	src = removesuffix(src, ".lzma")
-	src = removesuffix(src, ".gz")
-	src = removesuffix(src, ".xz")
+	src = normalize_extension(src)
 	src = removesuffix(src, ".ckl")
 
 	dest = f"{src}.ckl"
@@ -198,7 +230,7 @@ def compress_file(src, allow_pins, markov, gzip, keep):
 	del data
 
 	if dest == orig_src:
-		return
+		return dest
 		
 	try:
 		stat = os.stat(dest)
@@ -209,6 +241,8 @@ def compress_file(src, allow_pins, markov, gzip, keep):
 	except (FileNotFoundError, ValueError) as err:
 		print(f"crackle: Unable to write {dest}. Aborting.")
 		sys.exit()
+
+	return dest
 
 def removesuffix(x:str, suffix:str) -> str:
   if x.endswith(suffix):

--- a/crackle_cli/cli.py
+++ b/crackle_cli/cli.py
@@ -36,7 +36,7 @@ def normalize_extension(path):
 @click.option('-m', '--markov', default=None, help="If >0, use this order of markov compression for the crack code.", show_default=True)
 @click.option('-k', '--keep', default=False, is_flag=True, help="Keep the original file.", show_default=True)
 @click.option('-z', 'gzip', default=False, is_flag=True, help="Apply gzip compression after encoding.", show_default=True)
-@click.option('-M', '--cache-meta', default=False, is_flag=True, help="Create a sidecar parquet file with voxel counts, bounding boxes with filename .meta.parquet.", show_default=True)
+@click.option('-M', '--cache-meta', default=False, is_flag=True, help="Create a sidecar parquet file with voxel counts, bounding boxes with extension .meta.parquet.", show_default=True)
 @click.option('-S', '--skip-empty', default=False, is_flag=True, help="Skip sidecar generation for empty (background only) crackle files.", show_default=True)
 @click.argument("source", nargs=-1)
 def main(compress, info, test, labels, allow_pins, markov, source, keep, gzip, cache_meta, skip_empty):

--- a/crackle_cli/cli.py
+++ b/crackle_cli/cli.py
@@ -37,8 +37,9 @@ def normalize_extension(path):
 @click.option('-k', '--keep', default=False, is_flag=True, help="Keep the original file.", show_default=True)
 @click.option('-z', 'gzip', default=False, is_flag=True, help="Apply gzip compression after encoding.", show_default=True)
 @click.option('-M', '--cache-meta', default=False, is_flag=True, help="Create a sidecar parquet file with voxel counts, bounding boxes with filename .meta.parquet.", show_default=True)
+@click.option('-S', '--skip-empty', default=False, is_flag=True, help="Skip sidecar generation for empty (background only) crackle files.", show_default=True)
 @click.argument("source", nargs=-1)
-def main(compress, info, test, labels, allow_pins, markov, source, keep, gzip, cache_meta):
+def main(compress, info, test, labels, allow_pins, markov, source, keep, gzip, cache_meta, skip_empty):
 	"""
 	Compress and decompress crackle (.ckl) files to and from numpy (.npy) files.
 
@@ -66,7 +67,7 @@ def main(compress, info, test, labels, allow_pins, markov, source, keep, gzip, c
 			continue
 
 		if cache_meta and compress and orig_markov is None and normalize_extension(src).endswith('.ckl'):
-			create_sidecar_file(src)
+			create_sidecar_file(src, skip_empty)
 			continue
 
 		if compress:
@@ -76,7 +77,7 @@ def main(compress, info, test, labels, allow_pins, markov, source, keep, gzip, c
 
 		if cache_meta:
 			if ckl_path:
-				create_sidecar_file(ckl_path)
+				create_sidecar_file(ckl_path, skip_empty)
 
 def check_binary(src):
 	try:
@@ -157,8 +158,12 @@ def print_header(src):
 	print(f"num_labels: {num_labels}")
 	print()
 
-def create_sidecar_file(src):
+def create_sidecar_file(src, skip_empty):
 	arr = crackle.aload(src, allow_mmap=True)
+
+	if skip_empty and (arr.num_labels() <= 1) and (0 in arr):
+		return
+
 	meta_path = normalize_extension(src)
 	meta_path += ".meta.parquet"
 	arr.cache_meta(meta_path)

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,9 @@ setuptools.setup(
     "ccl": [ 
       "connected-components-3d",
     ],
+    "meta": [
+      "pyarrow",
+    ],
   },
   ext_modules=[
     Pybind11Extension(


### PR DESCRIPTION
Generate a parquet file with label, voxel counts, and bounding box. This can be used for faster analytics pipelines and potentially in the future for faster image queries.

Note that this file is only to make things more convenient and faster, it is entirely derived from information in the crackle file and nothing is lost if you lose the sidecar file.