### PR TITLE
perf: add point_cloud skip_background flag

### DIFF
--- a/automated_test.py
+++ b/automated_test.py
@@ -663,7 +663,7 @@ def test_point_cloud():
   ], dtype=np.uint32, order="F")
 
   binary = crackle.compress(input_arr)
-  ptc = crackle.point_cloud(binary, 0)[:,:2]
+  ptc = crackle.point_cloud(binary, 0, skip_background=False)[:,:2]
 
   sx, sy = input_arr.shape
 

--- a/crackle/array.py
+++ b/crackle/array.py
@@ -124,13 +124,15 @@ class CrackleArray:
   def point_cloud(
     self, 
     label:Optional[int] = None,
+    skip_background:bool = True,
     z_start:int = -1,
     z_end:int = -1,
   ) -> np.ndarray:
     return point_cloud(
       self.binary, label, 
+      skip_background=skip_background,
       z_start=z_start, z_end=z_end, 
-      parallel=self.parallel
+      parallel=self.parallel,
     )
 
   def connected_components(

--- a/crackle/codec.py
+++ b/crackle/codec.py
@@ -777,6 +777,7 @@ def point_cloud(
   parallel:int = 0,
   z_start:int = -1,
   z_end:int = -1,
+  skip_background:bool = True,
 ) -> Union[np.ndarray, Dict[int,np.ndarray]]:
   """
   Extract surface point clouds from the image without fully
@@ -826,7 +827,7 @@ def point_cloud(
   if parallel <= 0:
     parallel = mp.cpu_count()
 
-  ptc = fastcrackle.point_cloud(binary, z_start, z_end, label, parallel)
+  ptc = fastcrackle.point_cloud(binary, z_start, z_end, label, skip_background, parallel)
   
   if len(ptc) == 0:
     if label:

--- a/src/fastcrackle.cpp
+++ b/src/fastcrackle.cpp
@@ -317,6 +317,7 @@ py::dict point_cloud(
 	const int64_t z_start = 0, 
 	const int64_t z_end = -1,
 	const std::optional<std::vector<uint64_t>> labels = std::nullopt,
+	const bool skip_background = false,
 	const size_t parallel = 1
 ) {
 	py::buffer_info info = buffer.request();
@@ -326,7 +327,11 @@ py::dict point_cloud(
 	}
 
 	uint8_t* data = static_cast<uint8_t*>(info.ptr);
-	auto ptc = crackle::operations::point_cloud(data, info.size, z_start, z_end, labels, parallel);
+	auto ptc = crackle::operations::point_cloud(
+		data, info.size, 
+		z_start, z_end, 
+		labels, skip_background, parallel
+	);
 
 	py::dict py_ptc;
 	for (const auto& [key, vec] : ptc) {

--- a/src/operations.hpp
+++ b/src/operations.hpp
@@ -190,6 +190,7 @@ point_cloud(
 	int64_t z_start = -1,
 	int64_t z_end = -1,
 	const std::optional<std::vector<uint64_t>> labels = std::nullopt,
+	const bool skip_background = false,
 	size_t parallel = 1
 ) {
 	const CrackleHeader header = get_header(buffer, num_bytes);
@@ -232,7 +233,11 @@ point_cloud(
 			for (auto ptc_ccl : ptc_ccls) {
 				uint64_t current_label = label_map[label_i];
 				
-				if (selective && !labels_set.contains(current_label)) {
+				if (skip_background && current_label == 0) {
+					label_i++;
+					continue;
+				}
+				else if (selective && !labels_set.contains(current_label)) {
 					label_i++;
 					continue;
 				}
@@ -262,6 +267,7 @@ auto point_cloud(
 	int64_t z_start = -1,
 	int64_t z_end = -1,
 	const std::optional<std::vector<uint64_t>> labels = std::nullopt,
+	const bool skip_background = false,
 	size_t parallel = 1
 ) {
 	CrackleHeader header(buffer);
@@ -269,25 +275,29 @@ auto point_cloud(
 	if (header.data_width == 1) {
 		return point_cloud<uint8_t>(
 			buffer, num_bytes,
-			z_start, z_end, labels, parallel
+			z_start, z_end,
+			labels, skip_background, parallel
 		);
 	}
 	else if (header.data_width == 2) {
 		return point_cloud<uint16_t>(
 			buffer, num_bytes,
-			z_start, z_end, labels, parallel
+			z_start, z_end,
+			labels, skip_background, parallel
 		);
 	}
 	else if (header.data_width == 4) {
 		return point_cloud<uint32_t>(
 			buffer, num_bytes,
-			z_start, z_end, labels, parallel
+			z_start, z_end,
+			labels, skip_background, parallel
 		);
 	}
 	else {
 		return point_cloud<uint64_t>(
 			buffer, num_bytes,
-			z_start, z_end, labels, parallel
+			z_start, z_end,
+			labels, skip_background, parallel
 		);
 	}
 }
@@ -297,12 +307,14 @@ auto point_cloud(
 	const int64_t z_start = -1, 
 	const int64_t z_end = -1,
 	const std::optional<std::vector<uint64_t>> labels = std::nullopt,
+	const bool skip_background = false,
 	size_t parallel = 1
 ) {
 	return point_cloud(
 		buffer.data(),
 		buffer.size(),
-		z_start, z_end, labels, parallel
+		z_start, z_end, 
+		labels, skip_background, parallel
 	);
 }
 


### PR DESCRIPTION
Saves memory by not saving bg point clouds.
This can be more substantial if e.g. mask_except has previously been called.